### PR TITLE
Replaces vim.fn.getline with vim.fn.line

### DIFF
--- a/lua/wtf/ai.lua
+++ b/lua/wtf/ai.lua
@@ -24,7 +24,7 @@ local ai = function(additional_instructions)
     concatenatedDiagnostics = concatenatedDiagnostics .. diagnostic.severity .. ": " .. diagnostic.message .. "\n"
   end
 
-  local line = vim.fn.getline(".")
+  local line = vim.fn.line(".")
 
   local payload = "The coding language is "
     .. filetype


### PR DESCRIPTION
fixes bug where non-existent vim.fn.getline is called.  replaced with vim.fn.line