### PR TITLE
Allow OpenAI endpoint configuration via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ use({
     openai_api_key = "sk-xxxxxxxxxxxxxx",
     -- ChatGPT Model
     openai_model_id = "gpt-3.5-turbo",
+    -- Configure base url to work over proxy or with other api-compatable services
+    openai_base_url = "https://api.openai.com",
     -- Send code as well as diagnostics
     context = true,
     -- Set your preferred language for the response

--- a/lua/wtf/config.lua
+++ b/lua/wtf/config.lua
@@ -8,6 +8,7 @@ function M.setup(opts)
   local default_opts = {
     openai_api_key = nil,
     openai_model_id = "gpt-3.5-turbo",
+    openai_base_url = "https://api.openai.com",
     language = "english",
     search_engine = "google",
     context = true,
@@ -27,6 +28,7 @@ function M.setup(opts)
     winhighlight = { opts.winhighlight, "string" },
     openai_api_key = { opts.openai_api_key, { "string", "nil" } },
     openai_model_id = { opts.openai_model_id, "string" },
+    openai_base_url = { opts.openai_base_url, { "string", "nil" } },
     language = { opts.language, "string" },
     search_engine = {
       opts.search_engine,

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -126,8 +126,7 @@ function M.request(messages, callback, callbackTable)
   if isWindows ~= true then
     -- Linux
     curlRequest = string.format(
-      --'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
-        'curl -s ' 
+        'curl -s '
         .. base_url
         .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -67,12 +67,28 @@ local function get_api_key()
   return api_key
 end
 
+local function get_base_url()
+  local url = config.options.openai_base_url
+  if url == nil then
+    if vim.g.wtf_base_url_complained == nil then
+      local message =
+        "No OpenAI Base URL foun. Please set openai_base_url in the setup table. Defaulting to https://api.openai.com for now"
+      vim.fn.confirm(message, "&OK", 1, "Warning")
+      vim.g.wtf_base_url_complained = 1
+    end
+    return "https://api.openai.com"
+  end
+  return url
+end
+
 function M.request(messages, callback, callbackTable)
   local api_key = get_api_key()
 
   if api_key == nil then
     return nil
   end
+
+  local base_url = get_base_url()
 
   -- Check if curl is installed
   if vim.fn.executable("curl") == 0 then
@@ -110,7 +126,10 @@ function M.request(messages, callback, callbackTable)
   if isWindows ~= true then
     -- Linux
     curlRequest = string.format(
-      'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+      --'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+        'curl -s ' 
+        .. base_url
+        .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key
         .. '" --data-binary "@'
         .. tempFilePathEscaped
@@ -121,7 +140,9 @@ function M.request(messages, callback, callbackTable)
   else
     -- Windows
     curlRequest = string.format(
-      'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+        'curl -s '
+        .. base_url
+        .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key
         .. '" --data-binary "@'
         .. tempFilePathEscaped


### PR DESCRIPTION
When a user wants to use other API-compatible services or use a local instance of GPT, might be needed to redefine the OpenAI base URL.

With new configuration option `openai_base_url`, the user is able to set up whatever he wants.
For example usage with a local instance of "g4f":

Run g4f container:

```sh
docker run -p 8080:8080 -p 1337:1337 -p 7900:7900 --shm-size="2g" hlohaus789/g4f:latest
```

Update plugin config to use it:

```lua
return {
    {
        "piersolenski/wtf.nvim",
        dependencies = {
            "MunifTanjim/nui.nvim",
        },
        config = function ()
            local wtf = require("wtf")
            wtf.setup({
                openai_api_key = "sk-xxxxxxxxxxxxxx",
                openai_model_id = "gpt-3.5-turbo",
                openai_base_url = "http://127.0.0.1:1337",
            })
        end
    },
}
```