### PR TITLE
Add Feature for Secure API Key Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/piersolenski/wtf.nvim/assets/1285419/6697d9a5-c81c-4e54-b375-
 
 ## 🔩 Installation
 
-In order to use the AI functionality, set the environment variable `OPENAI_API_KEY` to your [openai api key](https://platform.openai.com/account/api-keys) (the search functionality will still work without it).
+In order to use the AI functionality, set the environment variable `OPENAI_API_KEY` to your [openai api key](https://platform.openai.com/account/api-keys), or set a command that returns it (the search functionality will still work without it).
 
 Install the plugin with your preferred package manager:
 
@@ -74,6 +74,8 @@ use({
     popup_type = "popup" | "horizontal" | "vertical",
     -- An alternative way to set your API key
     openai_api_key = "sk-xxxxxxxxxxxxxx",
+    -- Set the API key more securely, using a command that returns it. i.e 'pass show api/tokens/openai'
+    openai_api_key_cmd = "your command here", 
     -- ChatGPT Model
     openai_model_id = "gpt-3.5-turbo",
     -- Send code as well as diagnostics

--- a/lua/wtf/config.lua
+++ b/lua/wtf/config.lua
@@ -7,6 +7,7 @@ M.options = {}
 function M.setup(opts)
   local default_opts = {
     openai_api_key = nil,
+    openai_api_key_cmd = nil,
     openai_model_id = "gpt-3.5-turbo",
     language = "english",
     search_engine = "google",
@@ -26,6 +27,7 @@ function M.setup(opts)
   vim.validate({
     winhighlight = { opts.winhighlight, "string" },
     openai_api_key = { opts.openai_api_key, { "string", "nil" } },
+    openai_api_key_cmd = { opts.openai_api_key_cmd, { "string", "nil" } },
     openai_model_id = { opts.openai_model_id, "string" },
     language = { opts.language, "string" },
     search_engine = {

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -53,9 +53,9 @@ local function get_model_id()
 end
 
 local function get_api_key()
-  local api_key_cmd = config.options.openai_api_key_cmd
+  local api_key_cmd = config.options.openai_api_key_cmd -- Check for command in config
   if api_key_cmd ~= nil then
-    local handle = io.popen(api_key_cmd)
+    local handle = io.popen(api_key_cmd) -- Use user command to securely retrieve API key
     if handle ~= nil then
       local result = handle:read("*a")
       handle:close()
@@ -67,7 +67,7 @@ local function get_api_key()
     end
   end
 
-  local api_key = config.options.openai_api_key
+  local api_key = config.options.openai_api_key -- Use default behavior if no command or API key is set
   if api_key == nil then
     local key = os.getenv("OPENAI_API_KEY")
     if key ~= nil then

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -53,6 +53,20 @@ local function get_model_id()
 end
 
 local function get_api_key()
+  local api_key_cmd = config.options.openai_api_key_cmd
+  if api_key_cmd ~= nil then
+    local handle = io.popen(api_key_cmd)
+    if handle ~= nil then
+      local result = handle:read("*a")
+      handle:close()
+      if result ~= nil and result ~= "" then
+        return result:gsub("%s+", "") -- Remove any trailing whitespace
+      end
+    else
+      vim.notify("Failed to execute command to retrieve API key", vim.log.levels.ERROR)
+    end
+  end
+
   local api_key = config.options.openai_api_key
   if api_key == nil then
     local key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
Hey there,

I added a new feature to my fork and thought I'd open a PR since it's really small.

#### Main Changes

- **File:** `gpt.lua`
  - **Feature:** Checks for a command that returns the API key.
  - **Usage:** This feature is useful for securely retrieving the API key for those who use a password/secrets manager. For example, other plugins like [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) use this method.
  - **Personal Use Case:** I store my API keys using `pass` (the standard Unix password manager), and this feature is really useful for me.

#### Additional Changes

- **Comments:** Added comments in the code to explain my thought process.
- **README:** Included hints in the README for users to know how to use this feature.

Thanks!