### PR TITLE
Allow openai endpoint configuration via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ use({
     openai_api_key = "sk-xxxxxxxxxxxxxx",
     -- ChatGPT Model
     openai_model_id = "gpt-3.5-turbo",
+    -- Configure base url to work over proxy or with other api-compatable services
+    openai_base_url = "https://api.openai.com",
     -- Send code as well as diagnostics
     context = true,
     -- Set your preferred language for the response

--- a/lua/wtf/config.lua
+++ b/lua/wtf/config.lua
@@ -12,6 +12,7 @@ function M.setup(opts)
     language = "english",
     openai_api_key = nil,
     openai_model_id = "gpt-3.5-turbo",
+    openai_base_url = "https://api.openai.com",
     popup_type = "popup",
     search_engine = "google",
     hooks = {
@@ -28,6 +29,7 @@ function M.setup(opts)
     winhighlight = { opts.winhighlight, "string" },
     openai_api_key = { opts.openai_api_key, { "string", "nil" } },
     openai_model_id = { opts.openai_model_id, "string" },
+    openai_base_url = { opts.openai_base_url, { "string", "nil" } },
     language = { opts.language, "string" },
     search_engine = {
       opts.search_engine,

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -126,8 +126,7 @@ function M.request(messages, callback, callbackTable)
   if isWindows ~= true then
     -- Linux
     curlRequest = string.format(
-      --'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
-        'curl -s ' 
+        'curl -s '
         .. base_url
         .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -67,12 +67,28 @@ local function get_api_key()
   return api_key
 end
 
+local function get_base_url()
+  local url = config.options.openai_base_url
+  if url == nil then
+    if vim.g.wtf_base_url_complained == nil then
+      local message =
+        "No OpenAI Base URL foun. Please set openai_base_url in the setup table. Defaulting to https://api.openai.com for now"
+      vim.fn.confirm(message, "&OK", 1, "Warning")
+      vim.g.wtf_base_url_complained = 1
+    end
+    return "https://api.openai.com"
+  end
+  return url
+end
+
 function M.request(messages, callback, callbackTable)
   local api_key = get_api_key()
 
   if api_key == nil then
     return nil
   end
+
+  local base_url = get_base_url()
 
   -- Check if curl is installed
   if vim.fn.executable("curl") == 0 then
@@ -110,7 +126,10 @@ function M.request(messages, callback, callbackTable)
   if isWindows ~= true then
     -- Linux
     curlRequest = string.format(
-      'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+      --'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+        'curl -s ' 
+        .. base_url
+        .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key
         .. '" --data-binary "@'
         .. tempFilePathEscaped
@@ -121,7 +140,9 @@ function M.request(messages, callback, callbackTable)
   else
     -- Windows
     curlRequest = string.format(
-      'curl -s https://api.openai.com/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
+        'curl -s '
+        .. base_url
+        .. '/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer '
         .. api_key
         .. '" --data-binary "@'
         .. tempFilePathEscaped

--- a/lua/wtf/gpt.lua
+++ b/lua/wtf/gpt.lua
@@ -68,17 +68,7 @@ local function get_api_key()
 end
 
 local function get_base_url()
-  local url = config.options.openai_base_url
-  if url == nil then
-    if vim.g.wtf_base_url_complained == nil then
-      local message =
-        "No OpenAI Base URL foun. Please set openai_base_url in the setup table. Defaulting to https://api.openai.com for now"
-      vim.fn.confirm(message, "&OK", 1, "Warning")
-      vim.g.wtf_base_url_complained = 1
-    end
-    return "https://api.openai.com"
-  end
-  return url
+  return config.options.openai_base_url
 end
 
 function M.request(messages, callback, callbackTable)


### PR DESCRIPTION
Continue #18 .

> When a user wants to use other API-compatible services or use a local instance of GPT, might be needed to redefine the OpenAI base URL.

All the nil check code has been removed for the following reasons:
1. [As mentioned](https://github.com/piersolenski/wtf.nvim/pull/18#discussion_r1518263303), we have a fallback in place, so the check is not needed.
2. The `openai_base_url` **should not** be manually set by all users. Only users who want to use a custom URL will intentionally set it, as they know it’s necessary. Others who use the original endpoint shouldn't receive any warnings about the base URL.
    
