### PR TITLE
feat(search): add WSL support to get_open_command

### DIFF
--- a/lua/wtf/commands/search.lua
+++ b/lua/wtf/commands/search.lua
@@ -10,6 +10,8 @@ local function get_open_command()
     open_command = 'cmd /c start ""'
   elseif vim.fn.has("macunix") == 1 then
     open_command = "open"
+  elseif vim.fn.has("wsl") == 1 then
+    open_command = "wslview"
   else
     open_command = "xdg-open"
   end


### PR DESCRIPTION
Adds an elseif condition to detect WSL environments and use the `wslview` command in the `get_open_command` function. This improves compatibility when opening files or URLs on Windows Subsystem for Linux systems.