### PR TITLE
Fix: Provider URL setting in conf is invalid.

### DIFF
--- a/lua/wtf/ai/client.lua
+++ b/lua/wtf/ai/client.lua
@@ -72,7 +72,7 @@ end
 ---@return string? error
 local function client(system, message)
   local provider_id = config.options.provider
-  local provider = get_provider(provider_id)
+  local provider = config.options.providers[provider_id]
 
   local model_id = config.options.providers[provider_id].model_id
   local api_key = config.options.providers[provider_id].api_key

--- a/lua/wtf/config.lua
+++ b/lua/wtf/config.lua
@@ -1,13 +1,18 @@
 local providers = require("wtf.ai.providers")
 local validation = require("wtf.validation")
 
+function table.shallow_copy(t)
+  local t2 = {}
+  for k, v in pairs(t) do
+    t2[k] = v
+  end
+  return t2
+end
+
 local function create_provider_defaults()
   local defaults = {}
   for name, provider in pairs(providers) do
-    defaults[name] = {
-      model_id = provider.model_id,
-      api_key = provider.api_key,
-    }
+    defaults[name] = table.shallow_copy(provider)
   end
   return defaults
 end


### PR DESCRIPTION
**Overview**
  This PR fixes a bug where a custom `url` set for an AI provider in the setup function was not being used.

**The Problem**
In `lua/wtf/ai/client.lua`, the code retrieved the provider's configuration using `get_provider(provider_id`). However, this function returned the `default` configuration for the provider, ignoring any settings merged from the user's `wtf.setup({...})` call.
As a result, even if a user specified a custom `url` (e.g., to use a local Ollama instance), the program would fall back to the default official URL, rendering the custom setting ineffective.