### PR TITLE
fix: provider error formatting bugs and cleanup

### DIFF
--- a/lua/wtf/ai/providers/gemini.lua
+++ b/lua/wtf/ai/providers/gemini.lua
@@ -35,6 +35,6 @@ return {
     return response.choices[1].message.content
   end,
   format_error = function(response)
-    return response[1].error.message
+    return response.error.message
   end,
 }

--- a/lua/wtf/ai/providers/grok.lua
+++ b/lua/wtf/ai/providers/grok.lua
@@ -35,6 +35,6 @@ return {
     return response.choices[1].message.content
   end,
   format_error = function(response)
-    return response.error
+    return response.error.message
   end,
 }

--- a/lua/wtf/ai/providers/ollama.lua
+++ b/lua/wtf/ai/providers/ollama.lua
@@ -30,11 +30,6 @@ return {
   end,
   format_error = function(response)
     if type(response) == "table" then
-      -- Ollama not installed or binary path issue
-      if response.error and response.error.message then
-        return response.error.message
-      end
-      -- Ollama installed but API/model error
       if response.error and response.error.message then
         return response.error.message
       end

--- a/lua/wtf/util/remove_file_paths.lua
+++ b/lua/wtf/util/remove_file_paths.lua
@@ -1,9 +1,18 @@
 -- Remove data that is either sensitive or irrelevant to the search
 local function remove_user_data(inputString)
-  local username = vim.env.USER or vim.loop.os_get_passwd().username
+  local username = vim.env.USER or vim.env.USERNAME
+  if not username or username == "" then
+    local ok, pw = pcall(vim.loop.os_get_passwd)
+    username = (ok and pw and pw.username) or ""
+  end
+
+  -- If we couldn't determine a username, don't attempt pattern replacement
+  if username == "" then
+    return inputString
+  end
 
   -- Replace the username in the input string with '<user>'
-  local path_pattern = "[/\\]Users[/\\]" .. username
+  local path_pattern = "[/\\]Users[/\\]" .. vim.pesc(username)
 
   -- Replace the username in the input string only if it follows the /Users/ or \Users\ pattern
   local cleanedString = inputString:gsub(path_pattern, "/Users/<user>")

--- a/lua/wtf/util/remove_file_paths.lua
+++ b/lua/wtf/util/remove_file_paths.lua
@@ -1,6 +1,6 @@
 -- Remove data that is either sensitive or irrelevant to the search
 local function remove_user_data(inputString)
-  local username = vim.fn.system("whoami"):gsub("%s+", "")
+  local username = vim.env.USER or vim.loop.os_get_passwd().username
 
   -- Replace the username in the input string with '<user>'
   local path_pattern = "[/\\]Users[/\\]" .. username

--- a/lua/wtf/validation.lua
+++ b/lua/wtf/validation.lua
@@ -24,40 +24,7 @@ local function validate_picker(picker)
   return vim.tbl_contains({ "telescope", "snacks", "fzf-lua" }, picker)
 end
 
-local function create_deprecation_validator(old_key, new_key)
-  return function(val)
-    if val ~= nil then
-      vim.notify(
-        string.format("WTF %s should now be set via %s", old_key, new_key),
-        vim.log.levels.ERROR
-      )
-    end
-    return true
-  end
-end
-
 function M.validate_opts(opts)
-  -- TODO: Remove in future version
-  vim.validate(
-    "openai_api_key",
-    opts.openai_api_key,
-    create_deprecation_validator("openai_api_key", "providers.openai.api_key")
-  )
-  -- TODO: Remove in future version
-  vim.validate(
-    "openai_model_id",
-    opts.openai_model_id,
-    create_deprecation_validator("openai_model_id", "providers.openai.model_id")
-  )
-  vim.validate("context", opts.context, function(val)
-    if val ~= nil then
-      vim.notify(
-        "context is no longer supported, please remove it from your config",
-        vim.log.levels.ERROR
-      )
-    end
-    return true
-  end)
   vim.validate("winhighlight", opts.winhighlight, "string")
   vim.validate("provider", opts.provider, validate_provider, "supported provider")
   vim.validate("providers", opts.providers, { "table", "nil" })


### PR DESCRIPTION
## Summary
- Fix Gemini `format_error` crashing on API errors (accessed `response[1].error.message` instead of `response.error.message`)
- Fix Grok `format_error` returning a table instead of a string (returned `response.error` instead of `response.error.message`)
- Remove duplicate error check branch in Ollama provider
- Replace `whoami` subprocess call with `vim.env.USER` in path sanitization
- Remove deprecated config option validators (`openai_api_key`, `openai_model_id`, `context`)

## Test plan
- [x] `make lint` passes (0 warnings, 0 errors)
- [x] `make test` passes (25/25 tests)