### PR TITLE
feat: user-configurable per-provider temperature

### DIFF
--- a/.plans/remove-nui-dependency.md
+++ b/.plans/remove-nui-dependency.md
@@ -1,0 +1,141 @@
+# Plan: Remove nui.nvim dependency
+
+## Decisions
+
+- **Neovim minimum version:** 0.12+
+- **Split windows:** `vim.api.nvim_open_win()` with `split = "right" | "below"`
+- **Float window:** `vim.api.nvim_open_win()` with `relative = "editor"`
+- **Padding:** Preserve 1-cell padding for `popup` type by shrinking the content area
+- **Layout refresh:** Recalculate float geometry on `WinResized`; splits rely on the window manager
+
+## 1. Replace `lua/wtf/ui/popup.lua`
+
+Rewrite `M.show(message)` without any `require("nui.*")` calls.
+
+### Helpers
+
+```lua
+local function split_string_by_line(text)
+  local lines = {}
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    table.insert(lines, line)
+  end
+  return lines
+end
+
+local function create_buffer()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].readonly = true
+  vim.bo[buf].filetype = "markdown"
+  return buf
+end
+
+local function apply_window_options(win)
+  vim.wo[win].wrap = true
+  vim.wo[win].linebreak = true
+  vim.wo[win].winhighlight = config.options.winhighlight
+end
+```
+
+### `vertical` split
+
+```lua
+local win = vim.api.nvim_open_win(buf, true, {
+  split = "right",
+  width = math.floor(vim.o.columns * 0.5),
+})
+apply_window_options(win)
+```
+
+### `horizontal` split
+
+```lua
+local win = vim.api.nvim_open_win(buf, true, {
+  split = "below",
+  height = math.floor(vim.o.lines * 0.38),
+})
+apply_window_options(win)
+```
+
+### `popup` float
+
+```lua
+local padding = 1
+local total_width = math.floor(vim.o.columns * 0.62)
+local total_height = math.floor(vim.o.lines * 0.62)
+local content_width = math.max(1, total_width - padding * 2)
+local content_height = math.max(1, total_height - padding * 2)
+local row = math.floor((vim.o.lines - total_height) / 2)
+local col = math.floor((vim.o.columns - total_width) / 2)
+
+local win = vim.api.nvim_open_win(buf, true, {
+  relative = "editor",
+  row = row,
+  col = col,
+  width = content_width,
+  height = content_height,
+  style = "minimal",
+  border = "rounded",
+  zindex = 50,
+})
+apply_window_options(win)
+```
+
+### Autocmds
+
+- `BufLeave` for `popup` type: close the float with `vim.api.nvim_win_close(win, true)` and delete the scratch buffer.
+- `WinResized`: only for `popup` type, recompute geometry and call `nvim_win_set_config(win, new_config)`.
+
+### Return value
+
+Keep returning an object with `bufnr` and `win` (or equivalent) so callers and tests that mock `wtf.ui.popup` continue to work.
+
+```lua
+return { bufnr = buf, win = win }
+```
+
+## 2. Update `tests/minimal_init.lua`
+
+Remove nui cloning and runtime loading:
+
+```diff
+- local nui_dir = os.getenv("NUI_DIR") or "/tmp/nui.nvim"
+- local nui_repo = "https://github.com/MunifTanjim/nui.nvim"
+- clone_repo(nui_repo, nui_dir)
+  vim.opt.rtp:append(".")
+  vim.opt.rtp:append(plenary_dir)
+- vim.opt.rtp:append(nui_dir)
+  vim.cmd.runtime({ "plugin/plenary.vim" })
+- vim.cmd.runtime({ "plugin/nui.vim" })
+```
+
+## 3. Update documentation
+
+### `README.md`
+
+Remove `"MunifTanjim/nui.nvim",` from the `dependencies` / `requires` blocks.
+
+### `doc/wtf.nvim.txt`
+
+Remove `"MunifTanjim/nui.nvim",` from the installation examples.
+
+## 4. Version compatibility
+
+- New minimum remains **Neovim 0.12**.
+- `nvim_open_win` split windows require 0.10+, but this project already targets 0.12+.
+
+## 5. Known tradeoffs
+
+- **Manual layout math** replaces nui's `update_layout()`.
+- **Padding is handled by shrinking the content area**, so the visible border sits 1 cell outside the text region. This matches the previous visual spacing.
+- **No external UI framework** reduces dependencies and startup cost.
+
+## 6. Implementation checklist
+
+1. Rewrite `lua/wtf/ui/popup.lua` with native `nvim_open_win`.
+2. Update `tests/minimal_init.lua` to remove nui.
+3. Update `README.md` to remove nui.nvim dependency.
+4. Update `doc/wtf.nvim.txt` to remove nui.nvim dependency.
+5. Run `make lint`.
+6. Run `make test`.

--- a/.plans/remove-plenary-dependency.md
+++ b/.plans/remove-plenary-dependency.md
@@ -1,0 +1,153 @@
+# Plan: Remove plenary.nvim dependency
+
+## Decisions
+
+- **Neovim minimum version:** 0.12+
+- **HTTP replacement:** `vim.net.request()` (Option B)
+- **Test runner:** Replace `plenary.busted` with a custom luassert-based runner
+- **Path/file I/O:** Native `vim.fs` / `vim.fn`
+
+## 1. HTTP: replace `plenary.curl` with `vim.net.request()`
+
+Help docs: `:help vim.net.request()`
+
+### `lua/wtf/ai/client.lua`
+
+Replace the `curl.post` call in `make_http_request` with `vim.net.request("POST", ...)`:
+
+```lua
+vim.net.request("POST", url, {
+  headers = headers,
+  body = vim.json.encode(request_data),
+}, function(err, res)
+  vim.schedule(function()
+    if err then
+      -- vim.net.request gives us only a curl error string on 4xx/5xx.
+      -- Preserve the existing response shape so process_response keeps working.
+      coroutine.resume(co, { status = 400, body = err })
+    else
+      coroutine.resume(co, { status = 200, body = res.body })
+    end
+  end)
+end)
+```
+
+`process_response` stays essentially the same; it will decode `res.body` on success and return `"Bad or no response from API"` on HTTP errors.
+
+### `lua/wtf/ai/providers/copilot.lua`
+
+Replace the synchronous `curl.get` with `vim.net.request` wrapped in `vim.wait`:
+
+```lua
+local done = false
+local result, request_err
+
+vim.net.request("GET", "https://api.github.com/copilot_internal/v2/token", {
+  headers = {
+    ["Authorization"] = "token " .. oauth_token,
+    ["Accept"] = "application/json",
+  },
+}, function(err, res)
+  if err then
+    request_err = err
+  else
+    local token_data = vim.json.decode(res.body)
+    result = token_data.token
+  end
+  done = true
+end)
+
+vim.wait(30000, function() return done end)
+
+if request_err then
+  error("Failed to get Copilot token: " .. request_err)
+end
+return result
+```
+
+`vim.net.request()` has no built-in `timeout` option, so `vim.wait` caps the wait.
+
+## 2. Path / file I/O: replace `plenary.path` with built-ins
+
+Help docs: `:help vim.fs`, `:help vim.fs.joinpath()`, `:help filereadable()`, `:help readfile()`
+
+In `lua/wtf/ai/providers/copilot.lua`, replace the Copilot config file reading:
+
+```lua
+-- before
+local config_path = Path:new(config_dir):joinpath("github-copilot", filename)
+if config_path:exists() then
+  local config_data = vim.json.decode(config_path:read())
+  ...
+end
+
+-- after
+local config_path = vim.fs.joinpath(config_dir, "github-copilot", filename)
+if vim.fn.filereadable(config_path) == 1 then
+  local lines = vim.fn.readfile(config_path)
+  local config_data = vim.json.decode(table.concat(lines, "\n"))
+  ...
+end
+```
+
+## 3. Tests: remove `plenary.busted` entirely
+
+Add `luassert` as a dev dependency (via LuaRocks) and write a minimal in-Neovim runner in `tests/minimal_init.lua`.
+
+### Dev dependency
+
+```bash
+luarocks --lua-version 5.1 install luassert
+```
+
+### `Makefile`
+
+```makefile
+test:
+	@eval "$$(luarocks path --bin)" && \
+	nvim --headless --noplugin -u tests/minimal_init.lua -c "lua RunWtfTests('tests')"
+```
+
+### `tests/minimal_init.lua`
+
+Rough structure:
+
+- Set `rtp` to include the plugin and `nui.nvim`.
+- Load the nui plugin.
+- Pull in `LUA_PATH` / `LUA_CPATH` from the environment.
+- Set `_G.assert = require("luassert")`.
+- Implement lightweight `describe`, `it` (sync + async `done`), `before_each`, `after_each`, `pending`.
+- Implement `RunWtfTests(dir)` that globs `*_spec.lua`, runs them, prints a summary, and exits via `vim.cmd("0cq")` / `vim.cmd("1cq")`.
+
+The tests use `require("luassert.mock")`, `require("luassert.spy")`, and async `done`, so the runner must support those patterns.
+
+## 4. Documentation and packaging
+
+- `README.md`: remove `nvim-lua/plenary.nvim`; add Neovim ≥ 0.12 requirement.
+- `doc/wtf.nvim.txt`: same changes.
+- `Makefile`: update test command.
+- `.github/workflows/test.yml`: change matrix to `["v0.12.0", "nightly"]"; install `luassert` via LuaRocks.
+- `.github/workflows/check-models.yml`: remove the plenary clone step.
+
+## 5. Version compatibility
+
+- New minimum: **Neovim 0.12**.
+- `vim.net.request()` requires 0.12 (`:help news-0.12`).
+
+## 6. Known tradeoffs
+
+- **HTTP 4xx/5xx bodies are lost** because `vim.net.request()` uses `curl --fail` internally.
+- **No request timeout option** in `vim.net.request()`; mitigated with `vim.wait`.
+- **`curl` is still required** on the system.
+- **Custom test runner** must be maintained.
+
+## 7. Implementation checklist
+
+1. `lua/wtf/ai/client.lua` — switch POST to `vim.net.request`.
+2. `lua/wtf/ai/providers/copilot.lua` — switch GET to `vim.net.request`; replace `plenary.path`.
+3. `tests/minimal_init.lua` — rewrite as luassert-based custom runner.
+4. `Makefile` — update test command.
+5. `README.md` / `doc/wtf.nvim.txt` — remove plenary, add 0.12 requirement.
+6. `.github/workflows/test.yml` — bump matrix, install luassert.
+7. `.github/workflows/check-models.yml` — remove plenary clone.
+8. Run `make lint` and `make test`.

--- a/.plans/user-configurable-temperature.md
+++ b/.plans/user-configurable-temperature.md
@@ -1,0 +1,182 @@
+# Plan: User-configurable per-provider temperature
+
+## Goal
+
+Allow users to override or omit the `temperature` parameter on a per-provider basis, so models that reject `temperature` (e.g. OpenAI `o1`/`o3` reasoning models) can be used without changing the plugin's default behavior for other models.
+
+## Decisions
+
+- **Backward compatibility:** Default behavior stays unchanged. `diagnose` still sends `0.5` and `fix` still sends `0.1` unless the user overrides it.
+- **Override mechanism:** Add an optional `temperature` field to each provider's config.
+  - `number` — use this value instead of the command default.
+  - `false` — explicitly omit `temperature` from the request body.
+  - `nil` or missing — use the command default (`0.5` for diagnose, `0.1` for fix).
+- **Lua nil limitation:** Because `temperature = nil` is indistinguishable from a missing key after `vim.tbl_deep_extend`, `false` is used as the explicit "omit" sentinel.
+
+## 1. Update the adapter type
+
+### `lua/wtf/ai/providers/init.lua`
+
+Add an optional `temperature` field to the `Wtf.Adapter` class definition:
+
+```lua
+---@field temperature number | false | nil Optional override; false omits temperature from requests
+```
+
+## 2. Compute effective temperature in the client
+
+### `lua/wtf/ai/client.lua`
+
+Before calling `provider.format_request`, resolve the final temperature value:
+
+```lua
+local function resolve_temperature(provider, default_temperature)
+  if provider.temperature == false then
+    return nil -- explicitly omitted
+  end
+
+  if type(provider.temperature) == "number" then
+    return provider.temperature
+  end
+
+  return default_temperature
+end
+```
+
+Then pass the resolved value:
+
+```lua
+local effective_temperature = resolve_temperature(provider, temperature)
+
+local request_data = provider.format_request({
+  model = model_id,
+  max_tokens = DEFAULT_MAX_TOKENS,
+  system = system,
+  message = message,
+  temperature = effective_temperature,
+})
+```
+
+## 3. Conditionally include temperature in every provider
+
+### All files under `lua/wtf/ai/providers/*.lua`
+
+Update each `format_request` function to only include `temperature` when it is non-nil.
+
+Example for `lua/wtf/ai/providers/openai.lua`:
+
+```lua
+format_request = function(data)
+  local body = {
+    model = data.model,
+    messages = {
+      { role = "system", content = data.system },
+      { role = "user", content = data.message },
+    },
+  }
+
+  if data.temperature ~= nil then
+    body.temperature = data.temperature
+  end
+
+  return body
+end
+```
+
+Apply the same pattern to:
+
+- `lua/wtf/ai/providers/anthropic.lua`
+- `lua/wtf/ai/providers/copilot.lua`
+- `lua/wtf/ai/providers/deepseek.lua`
+- `lua/wtf/ai/providers/gemini.lua`
+- `lua/wtf/ai/providers/grok.lua`
+- `lua/wtf/ai/providers/ollama.lua`
+- `lua/wtf/ai/providers/opencode.lua`
+- `lua/wtf/ai/providers/openai.lua`
+
+## 4. Document the new provider option
+
+### `README.md`
+
+Update the provider configuration example:
+
+```lua
+providers = {
+  openai = {
+    model_id = "gpt-4o",
+    -- Use a custom temperature (default is 0.5 for diagnose, 0.1 for fix)
+    temperature = 0.7,
+    -- Set to false to omit temperature entirely for models that don't support it
+    -- temperature = false,
+  },
+}
+```
+
+### `doc/wtf.nvim.txt`
+
+Mirror the same documentation in the Vim help file.
+
+## 5. Validation
+
+### `lua/wtf/validation.lua`
+
+Optionally validate that `provider.temperature` is one of `number`, `false`, or `nil` when present. This catches typos early.
+
+```lua
+local function validate_temperature(value)
+  return value == nil or value == false or type(value) == "number"
+end
+```
+
+## 6. Tests
+
+### `tests/wtf/providers_spec.lua`
+
+Add unit-style tests for provider request formatting that don't require API keys. For each provider:
+
+1. Default behavior includes `temperature` when a numeric value is passed.
+2. `temperature = false` causes the key to be absent from the encoded request body.
+3. `temperature = <number>` uses the configured value instead of the default.
+
+Example assertion:
+
+```lua
+local openai = require("wtf.ai.providers.openai")
+local request = openai.format_request({
+  model = "o3-mini",
+  system = "sys",
+  message = "msg",
+  max_tokens = 4096,
+  temperature = nil,
+})
+assert.is_nil(request.temperature)
+```
+
+## 7. Implementation checklist
+
+1. `lua/wtf/ai/providers/init.lua` — document `temperature` field on `Wtf.Adapter`.
+2. `lua/wtf/ai/client.lua` — add `resolve_temperature` helper and pass effective value.
+3. `lua/wtf/ai/providers/*.lua` — conditionally include `temperature` in each `format_request`.
+4. `lua/wtf/validation.lua` — optionally validate `provider.temperature` type.
+5. `README.md` — document the new `temperature` option.
+6. `doc/wtf.nvim.txt` — document the new `temperature` option.
+7. `tests/wtf/providers_spec.lua` — add formatting tests.
+8. Run `make lint` and `make test`.
+
+## 8. Example user config
+
+```lua
+require("wtf").setup({
+  provider = "openai",
+  providers = {
+    openai = {
+      model_id = "o3-mini",
+      temperature = false, -- o3-mini does not support temperature
+    },
+    anthropic = {
+      model_id = "claude-sonnet-4-6",
+      temperature = 0.7, -- override default
+    },
+  },
+})
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Why spend time copying and pasting, or worse yet, typing out diagnostic messages
 
 ### Providers
 
-Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com) and [OpenAI](https://openai.com).
+Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com), [OpenAI](https://openai.com) and [OpenCode](https://opencode.ai).
 
 ### Multiple picker support
 
@@ -151,6 +151,9 @@ export GROK_API_KEY=your-api-key
 
 // OpenAI
 export OPENAI_API_KEY=your-api-key
+
+// OpenCode
+export OPENCODE_API_KEY=your-api-key
 ```
 
 You can also set or override API keys in your config, but it is recommended to use environment variables.
@@ -164,7 +167,7 @@ You can also set or override API keys in your config, but it is recommended to u
   -- Default AI popup type
   popup_type = "popup" | "horizontal" | "vertical",
   -- The default provider
-  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
   -- Configure providers
   providers = {
     anthropic = {

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ You can also set or override API keys in your config, but it is recommended to u
       api_key = "32lkj23sdjke223ksdlfk" | function() os.getenv("API_KEY") end,
       -- Your preferred model
       model_id = "claude-3-5-sonnet-20241022",
+      -- Use a custom temperature (default is 0.5 for diagnose, 0.1 for fix)
+      temperature = 0.7,
+      -- Set to false to omit temperature entirely for models that don't support it
+      -- temperature = false,
     },
   },
   -- Set your preferred language for the response

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -215,6 +215,10 @@ CONFIGURATION                                *wtf.nvim-wtf.nvim-configuration*
           api_key = "32lkj23sdjke223ksdlfk" | function() os.getenv("API_KEY") end,
           -- Your preferred model
           model_id = "claude-3-5-sonnet-20241022",
+          -- Use a custom temperature (default is 0.5 for diagnose, 0.1 for fix)
+          temperature = 0.7,
+          -- Set to false to omit temperature entirely for models that don't support it
+          -- temperature = false,
         },
       },
       -- Set your preferred language for the response

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -60,8 +60,8 @@ PROVIDERS ~
 
 Support for Anthropic <https://www.anthropic.com>, Copilot
 <https://github.com/copilot>, DeepSeek <https://www.deepseek.com>, Gemini
-<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>
-and OpenAI <https://openai.com>.
+<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>,
+OpenAI <https://openai.com> and OpenCode <https://opencode.ai>.
 
 
 MULTIPLE PICKER SUPPORT ~
@@ -189,6 +189,9 @@ variable for your provider of choice:
     
     // OpenAI
     export OPENAI_API_KEY=your-api-key
+    
+    // OpenCode
+    export OPENCODE_API_KEY=your-api-key
 <
 
 You can also set or override API keys in your config, but it is recommended to
@@ -204,7 +207,7 @@ CONFIGURATION                                *wtf.nvim-wtf.nvim-configuration*
       -- Default AI popup type
       popup_type = "popup" | "horizontal" | "vertical",
       -- The default provider
-      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
       -- Configure providers
       providers = {
         anthropic = {

--- a/lua/wtf/ai/client.lua
+++ b/lua/wtf/ai/client.lua
@@ -17,6 +17,22 @@ local function build_headers(headers, api_key)
   return processed_headers
 end
 
+--- Resolves the effective temperature for a provider
+---@param provider table
+---@param default_temperature number
+---@return number | nil
+local function resolve_temperature(provider, default_temperature)
+  if provider.temperature == false then
+    return nil
+  end
+
+  if type(provider.temperature) == "number" then
+    return provider.temperature
+  end
+
+  return default_temperature
+end
+
 --- Processes HTTP response from AI provider API
 ---@param response table
 ---@param provider_config table
@@ -89,12 +105,14 @@ local function client(system, message, temperature)
     api_key = result
   end
 
+  local effective_temperature = resolve_temperature(provider, temperature)
+
   local request_data = provider.format_request({
     model = model_id,
     max_tokens = DEFAULT_MAX_TOKENS,
     system = system,
     message = message,
-    temperature = temperature,
+    temperature = effective_temperature,
   })
 
   local headers = build_headers(provider.headers, api_key)

--- a/lua/wtf/ai/providers/anthropic.lua
+++ b/lua/wtf/ai/providers/anthropic.lua
@@ -15,11 +15,10 @@ return {
     return get_env_var("ANTHROPIC_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       max_tokens = data.max_tokens,
       system = data.system,
-      temperature = data.temperature,
       messages = {
         {
           role = "user",
@@ -27,6 +26,12 @@ return {
         },
       },
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.content[1].text

--- a/lua/wtf/ai/providers/copilot.lua
+++ b/lua/wtf/ai/providers/copilot.lua
@@ -74,10 +74,9 @@ return {
     return get_copilot_token()
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       max_tokens = data.max_tokens,
-      temperature = data.temperature,
       messages = {
         {
           role = "system",
@@ -89,6 +88,12 @@ return {
         },
       },
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/deepseek.lua
+++ b/lua/wtf/ai/providers/deepseek.lua
@@ -14,7 +14,7 @@ return {
     return get_env_var("DEEPSEEK_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       messages = {
         {
@@ -28,8 +28,13 @@ return {
       },
       max_tokens = data.max_tokens,
       stream = false,
-      temperature = data.temperature,
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/gemini.lua
+++ b/lua/wtf/ai/providers/gemini.lua
@@ -14,7 +14,7 @@ return {
     return get_env_var("GEMINI_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       messages = {
         {
@@ -28,8 +28,13 @@ return {
       },
       max_tokens = data.max_tokens,
       stream = false,
-      temperature = data.temperature,
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/grok.lua
+++ b/lua/wtf/ai/providers/grok.lua
@@ -14,7 +14,7 @@ return {
     return get_env_var("GROK_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       messages = {
         {
@@ -28,8 +28,13 @@ return {
       },
       max_tokens = data.max_tokens,
       stream = false,
-      temperature = data.temperature,
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,6 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
-M.opencode_go = require("wtf.ai.providers.opencode-go")
+M.opencode = require("wtf.ai.providers.opencode")
 
 return M

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -4,6 +4,7 @@
 ---@field url string The base URL of the LLM API
 ---@field headers table<string, string> The headers to pass to the request
 ---@field api_key string | nil | fun(): string | nil Retrieve API key
+---@field temperature number | false | nil Optional override; false omits temperature from requests
 ---@field format_request fun(data: table): table Function to format request data
 ---@field format_response fun(response: table): string Function to format API response
 ---@field format_error fun(response: table): string Function to format error response

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,5 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
+M.opencode_go = require("wtf.ai.providers.opencode-go")
 
 return M

--- a/lua/wtf/ai/providers/ollama.lua
+++ b/lua/wtf/ai/providers/ollama.lua
@@ -9,7 +9,7 @@ return {
   },
   api_key = nil,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
       messages = {
         {
@@ -22,8 +22,13 @@ return {
         },
       },
       max_tokens = data.max_tokens,
-      temperature = data.temperature,
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/openai.lua
+++ b/lua/wtf/ai/providers/openai.lua
@@ -14,9 +14,8 @@ return {
     return get_env_var("OPENAI_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
-      temperature = data.temperature,
       messages = {
         {
           role = "system",
@@ -28,6 +27,12 @@ return {
         },
       },
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/opencode-go.lua
+++ b/lua/wtf/ai/providers/opencode-go.lua
@@ -1,0 +1,38 @@
+local get_env_var = require("wtf.util.get_env_var")
+
+---@type Wtf.Adapter
+return {
+  name = "opencode-go",
+  formatted_name = "OpenCode Go",
+  url = "https://opencode.ai/zen/go/v1/chat/completions",
+  model_id = "opencode-go/qwen3.7-plus",
+  headers = {
+    ["Content-Type"] = "application/json",
+    Authorization = "Bearer ${api_key}",
+  },
+  api_key = function()
+    return get_env_var("OPENCODE_API_KEY")
+  end,
+  format_request = function(data)
+    return {
+      model = data.model,
+      temperature = data.temperature,
+      messages = {
+        {
+          role = "system",
+          content = data.system,
+        },
+        {
+          role = "user",
+          content = data.message,
+        },
+      },
+    }
+  end,
+  format_response = function(response)
+    return response.choices[1].message.content
+  end,
+  format_error = function(response)
+    return response.error.message
+  end,
+}

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -2,8 +2,8 @@ local get_env_var = require("wtf.util.get_env_var")
 
 ---@type Wtf.Adapter
 return {
-  name = "opencode-go",
-  formatted_name = "OpenCode Go",
+  name = "opencode",
+  formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
   model_id = "opencode-go/qwen3.7-plus",
   headers = {

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -14,9 +14,8 @@ return {
     return get_env_var("OPENCODE_API_KEY")
   end,
   format_request = function(data)
-    return {
+    local body = {
       model = data.model,
-      temperature = data.temperature,
       messages = {
         {
           role = "system",
@@ -28,6 +27,12 @@ return {
         },
       },
     }
+
+    if data.temperature ~= nil and data.temperature ~= false then
+      body.temperature = data.temperature
+    end
+
+    return body
   end,
   format_response = function(response)
     return response.choices[1].message.content

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -5,7 +5,7 @@ return {
   name = "opencode",
   formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
-  model_id = "opencode-go/qwen3.7-plus",
+  model_id = "qwen3.7-plus",
   headers = {
     ["Content-Type"] = "application/json",
     Authorization = "Bearer ${api_key}",

--- a/lua/wtf/validation.lua
+++ b/lua/wtf/validation.lua
@@ -20,6 +20,10 @@ local function validate_popup_type(popup_type)
   return vim.tbl_contains({ "horizontal", "vertical", "popup" }, popup_type)
 end
 
+local function validate_temperature(temperature)
+  return temperature == nil or temperature == false or type(temperature) == "number"
+end
+
 local function validate_picker(picker)
   return vim.tbl_contains({ "telescope", "snacks", "fzf-lua" }, picker)
 end
@@ -40,6 +44,17 @@ function M.validate_opts(opts)
   vim.validate("popup_type", opts.popup_type, validate_popup_type, "supported popup type")
   vim.validate("request_started", opts.hooks.request_started, { "function", "nil" })
   vim.validate("request_finished", opts.hooks.request_finished, { "function", "nil" })
+
+  if opts.providers then
+    for provider_name, provider_opts in pairs(opts.providers) do
+      vim.validate(
+        string.format("providers.%s.temperature", provider_name),
+        provider_opts.temperature,
+        validate_temperature,
+        "number, false, or nil"
+      )
+    end
+  end
 end
 
 return M

--- a/plugin/wtf.lua
+++ b/plugin/wtf.lua
@@ -1,8 +1,3 @@
-if vim.fn.has("nvim-0.7.0") == 0 then
-  vim.api.nvim_err_writeln("wtf requires at least nvim-0.7.0.1")
-  return
-end
-
 -- Automatically executed on startup
 if vim.g.loaded_wtf then
   return

--- a/tests/wtf/providers_spec.lua
+++ b/tests/wtf/providers_spec.lua
@@ -2,6 +2,64 @@ local client = require("wtf.ai.client")
 local config = require("wtf.config")
 local providers = require("wtf.ai.providers")
 
+local function get_temperature(body)
+  return body.temperature
+end
+
+describe("Provider request formatting", function()
+  for provider_name, provider in pairs(providers) do
+    describe(provider.formatted_name, function()
+      it("includes temperature when a numeric value is passed", function()
+        local request = provider.format_request({
+          model = "test-model",
+          system = "sys",
+          message = "msg",
+          max_tokens = 4096,
+          temperature = 0.7,
+        })
+
+        assert.are.equal(0.7, get_temperature(request))
+      end)
+
+      it("omits temperature when temperature is false", function()
+        local request = provider.format_request({
+          model = "test-model",
+          system = "sys",
+          message = "msg",
+          max_tokens = 4096,
+          temperature = false,
+        })
+
+        assert.is_nil(get_temperature(request))
+      end)
+
+      it("omits temperature when temperature is nil", function()
+        local request = provider.format_request({
+          model = "test-model",
+          system = "sys",
+          message = "msg",
+          max_tokens = 4096,
+          temperature = nil,
+        })
+
+        assert.is_nil(get_temperature(request))
+      end)
+
+      it("uses a custom temperature value instead of the default", function()
+        local request = provider.format_request({
+          model = "test-model",
+          system = "sys",
+          message = "msg",
+          max_tokens = 4096,
+          temperature = 0.3,
+        })
+
+        assert.are.equal(0.3, get_temperature(request))
+      end)
+    end)
+  end
+end)
+
 -- NOTE: In order for this integration test to pass, the following must be true:
 -- 1. All environment variables are set correctly.
 -- 2. All providers that require a balance are funded.

--- a/tests/wtf/wtf_spec.lua
+++ b/tests/wtf/wtf_spec.lua
@@ -9,6 +9,12 @@ describe("Setup", function()
     })
   end)
 
+  it("accepts opencode as a provider", function()
+    wtf.setup({
+      provider = "opencode",
+    })
+  end)
+
   it("rejects a broken config", function()
     assert.error_matches(function()
       wtf.setup({


### PR DESCRIPTION
# Plan: User-configurable per-provider temperature

## Goal

Allow users to override or omit the `temperature` parameter on a per-provider basis, so models that reject `temperature` (e.g. OpenAI `o1`/`o3` reasoning models) can be used without changing the plugin's default behavior for other models.

## Decisions

- **Backward compatibility:** Default behavior stays unchanged. `diagnose` still sends `0.5` and `fix` still sends `0.1` unless the user overrides it.
- **Override mechanism:** Add an optional `temperature` field to each provider's config.
  - `number` — use this value instead of the command default.
  - `false` — explicitly omit `temperature` from the request body.
  - `nil` or missing — use the command default (`0.5` for diagnose, `0.1` for fix).
- **Lua nil limitation:** Because `temperature = nil` is indistinguishable from a missing key after `vim.tbl_deep_extend`, `false` is used as the explicit "omit" sentinel.

## 1. Update the adapter type

### `lua/wtf/ai/providers/init.lua`

Add an optional `temperature` field to the `Wtf.Adapter` class definition:

```lua
---@field temperature number | false | nil Optional override; false omits temperature from requests
```

## 2. Compute effective temperature in the client

### `lua/wtf/ai/client.lua`

Before calling `provider.format_request`, resolve the final temperature value:

```lua
local function resolve_temperature(provider, default_temperature)
  if provider.temperature == false then
    return nil -- explicitly omitted
  end

  if type(provider.temperature) == "number" then
    return provider.temperature
  end

  return default_temperature
end
```

Then pass the resolved value:

```lua
local effective_temperature = resolve_temperature(provider, temperature)

local request_data = provider.format_request({
  model = model_id,
  max_tokens = DEFAULT_MAX_TOKENS,
  system = system,
  message = message,
  temperature = effective_temperature,
})
```

## 3. Conditionally include temperature in every provider

### All files under `lua/wtf/ai/providers/*.lua`

Update each `format_request` function to only include `temperature` when it is non-nil.

Example for `lua/wtf/ai/providers/openai.lua`:

```lua
format_request = function(data)
  local body = {
    model = data.model,
    messages = {
      { role = "system", content = data.system },
      { role = "user", content = data.message },
    },
  }

  if data.temperature ~= nil then
    body.temperature = data.temperature
  end

  return body
end
```

Apply the same pattern to:

- `lua/wtf/ai/providers/anthropic.lua`
- `lua/wtf/ai/providers/copilot.lua`
- `lua/wtf/ai/providers/deepseek.lua`
- `lua/wtf/ai/providers/gemini.lua`
- `lua/wtf/ai/providers/grok.lua`
- `lua/wtf/ai/providers/ollama.lua`
- `lua/wtf/ai/providers/opencode.lua`
- `lua/wtf/ai/providers/openai.lua`

## 4. Document the new provider option

### `README.md`

Update the provider configuration example:

```lua
providers = {
  openai = {
    model_id = "gpt-4o",
    -- Use a custom temperature (default is 0.5 for diagnose, 0.1 for fix)
    temperature = 0.7,
    -- Set to false to omit temperature entirely for models that don't support it
    -- temperature = false,
  },
}
```

### `doc/wtf.nvim.txt`

Mirror the same documentation in the Vim help file.

## 5. Validation

### `lua/wtf/validation.lua`

Optionally validate that `provider.temperature` is one of `number`, `false`, or `nil` when present. This catches typos early.

```lua
local function validate_temperature(value)
  return value == nil or value == false or type(value) == "number"
end
```

## 6. Tests

### `tests/wtf/providers_spec.lua`

Add unit-style tests for provider request formatting that don't require API keys. For each provider:

1. Default behavior includes `temperature` when a numeric value is passed.
2. `temperature = false` causes the key to be absent from the encoded request body.
3. `temperature = <number>` uses the configured value instead of the default.

Example assertion:

```lua
local openai = require("wtf.ai.providers.openai")
local request = openai.format_request({
  model = "o3-mini",
  system = "sys",
  message = "msg",
  max_tokens = 4096,
  temperature = nil,
})
assert.is_nil(request.temperature)
```

## 7. Implementation checklist

1. `lua/wtf/ai/providers/init.lua` — document `temperature` field on `Wtf.Adapter`.
2. `lua/wtf/ai/client.lua` — add `resolve_temperature` helper and pass effective value.
3. `lua/wtf/ai/providers/*.lua` — conditionally include `temperature` in each `format_request`.
4. `lua/wtf/validation.lua` — optionally validate `provider.temperature` type.
5. `README.md` — document the new `temperature` option.
6. `doc/wtf.nvim.txt` — document the new `temperature` option.
7. `tests/wtf/providers_spec.lua` — add formatting tests.
8. Run `make lint` and `make test`.

## 8. Example user config

```lua
require("wtf").setup({
  provider = "openai",
  providers = {
    openai = {
      model_id = "o3-mini",
      temperature = false, -- o3-mini does not support temperature
    },
    anthropic = {
      model_id = "claude-sonnet-4-6",
      temperature = 0.7, -- override default
    },
  },
})
```