### PR TITLE
feat: remove nui.nvim dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Why spend time copying and pasting, or worse yet, typing out diagnostic messages
 
 ### Providers
 
-Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com) and [OpenAI](https://openai.com).
+Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com), [OpenAI](https://openai.com) and [OpenCode](https://opencode.ai).
 
 ### Multiple picker support
 
@@ -151,6 +151,9 @@ export GROK_API_KEY=your-api-key
 
 // OpenAI
 export OPENAI_API_KEY=your-api-key
+
+// OpenCode
+export OPENCODE_API_KEY=your-api-key
 ```
 
 You can also set or override API keys in your config, but it is recommended to use environment variables.
@@ -164,7 +167,7 @@ You can also set or override API keys in your config, but it is recommended to u
   -- Default AI popup type
   popup_type = "popup" | "horizontal" | "vertical",
   -- The default provider
-  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
   -- Configure providers
   providers = {
     anthropic = {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Install the plugin with your preferred package manager:
   "piersolenski/wtf.nvim",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "MunifTanjim/nui.nvim",
     -- Optional: For WtfGrepHistory (pick one)
     "nvim-telescope/telescope.nvim",
     -- "folke/snacks.nvim",
@@ -125,7 +124,6 @@ use({
   end,
   requires = {
     "nvim-lua/plenary.nvim",
-    "MunifTanjim/nui.nvim",
     -- Optional: For WtfGrepHistory (pick one)
     "nvim-telescope/telescope.nvim",
     -- "folke/snacks.nvim",

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -83,7 +83,6 @@ LAZY.NVIM ~
       "piersolenski/wtf.nvim",
       dependencies = {
         "nvim-lua/plenary.nvim",
-        "MunifTanjim/nui.nvim",
         -- Optional: For WtfGrepHistory (pick one)
         "nvim-telescope/telescope.nvim",
         -- "folke/snacks.nvim",
@@ -162,7 +161,6 @@ PACKER.NVIM ~
       end,
       requires = {
         "nvim-lua/plenary.nvim",
-        "MunifTanjim/nui.nvim",
         -- Optional: For WtfGrepHistory (pick one)
         "nvim-telescope/telescope.nvim",
         -- "folke/snacks.nvim",

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -60,8 +60,8 @@ PROVIDERS ~
 
 Support for Anthropic <https://www.anthropic.com>, Copilot
 <https://github.com/copilot>, DeepSeek <https://www.deepseek.com>, Gemini
-<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>
-and OpenAI <https://openai.com>.
+<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>,
+OpenAI <https://openai.com> and OpenCode <https://opencode.ai>.
 
 
 MULTIPLE PICKER SUPPORT ~
@@ -189,6 +189,9 @@ variable for your provider of choice:
     
     // OpenAI
     export OPENAI_API_KEY=your-api-key
+    
+    // OpenCode
+    export OPENCODE_API_KEY=your-api-key
 <
 
 You can also set or override API keys in your config, but it is recommended to
@@ -204,7 +207,7 @@ CONFIGURATION                                *wtf.nvim-wtf.nvim-configuration*
       -- Default AI popup type
       popup_type = "popup" | "horizontal" | "vertical",
       -- The default provider
-      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
       -- Configure providers
       providers = {
         anthropic = {

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,6 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
-M.opencode_go = require("wtf.ai.providers.opencode-go")
+M.opencode = require("wtf.ai.providers.opencode")
 
 return M

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,5 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
+M.opencode_go = require("wtf.ai.providers.opencode-go")
 
 return M

--- a/lua/wtf/ai/providers/opencode-go.lua
+++ b/lua/wtf/ai/providers/opencode-go.lua
@@ -1,0 +1,38 @@
+local get_env_var = require("wtf.util.get_env_var")
+
+---@type Wtf.Adapter
+return {
+  name = "opencode-go",
+  formatted_name = "OpenCode Go",
+  url = "https://opencode.ai/zen/go/v1/chat/completions",
+  model_id = "opencode-go/qwen3.7-plus",
+  headers = {
+    ["Content-Type"] = "application/json",
+    Authorization = "Bearer ${api_key}",
+  },
+  api_key = function()
+    return get_env_var("OPENCODE_API_KEY")
+  end,
+  format_request = function(data)
+    return {
+      model = data.model,
+      temperature = data.temperature,
+      messages = {
+        {
+          role = "system",
+          content = data.system,
+        },
+        {
+          role = "user",
+          content = data.message,
+        },
+      },
+    }
+  end,
+  format_response = function(response)
+    return response.choices[1].message.content
+  end,
+  format_error = function(response)
+    return response.error.message
+  end,
+}

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -2,8 +2,8 @@ local get_env_var = require("wtf.util.get_env_var")
 
 ---@type Wtf.Adapter
 return {
-  name = "opencode-go",
-  formatted_name = "OpenCode Go",
+  name = "opencode",
+  formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
   model_id = "opencode-go/qwen3.7-plus",
   headers = {

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -5,7 +5,7 @@ return {
   name = "opencode",
   formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
-  model_id = "opencode-go/qwen3.7-plus",
+  model_id = "qwen3.7-plus",
   headers = {
     ["Content-Type"] = "application/json",
     Authorization = "Bearer ${api_key}",

--- a/lua/wtf/ui/popup.lua
+++ b/lua/wtf/ui/popup.lua
@@ -1,5 +1,3 @@
-local Popup = require("nui.popup")
-local Split = require("nui.split")
 local config = require("wtf.config")
 
 local function split_string_by_line(text)
@@ -10,75 +8,106 @@ local function split_string_by_line(text)
   return lines
 end
 
+local function create_buffer()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].readonly = true
+  vim.bo[buf].filetype = "markdown"
+  return buf
+end
+
+local function apply_window_options(win)
+  vim.wo[win].wrap = true
+  vim.wo[win].linebreak = true
+  vim.wo[win].winhighlight = config.options.winhighlight
+end
+
 local M = {}
 
 M.show = function(message)
   local formatted_message = split_string_by_line(message)
-
-  local event = require("nui.utils.autocmd").event
-
-  local popup
-  local popup_opts = {
-    relative = "editor",
-    buf_options = {
-      modifiable = false,
-      readonly = true,
-      filetype = "markdown",
-    },
-    win_options = {
-      wrap = true,
-      linebreak = true,
-      winhighlight = config.options.winhighlight,
-    },
-  }
-
   local popup_type = config.options.popup_type
 
+  local buf = create_buffer()
+  local win
+
   if popup_type == "vertical" then
-    popup = Split(vim.tbl_deep_extend("keep", popup_opts, {
-      position = "right",
-      size = "50%",
-    }))
+    win = vim.api.nvim_open_win(buf, true, {
+      split = "right",
+      width = math.floor(vim.o.columns * 0.5),
+    })
+    apply_window_options(win)
   elseif popup_type == "horizontal" then
-    popup = Split(vim.tbl_deep_extend("keep", popup_opts, {
-      position = "bottom",
-      size = "38%",
-    }))
+    win = vim.api.nvim_open_win(buf, true, {
+      split = "below",
+      height = math.floor(vim.o.lines * 0.38),
+    })
+    apply_window_options(win)
   elseif popup_type == "popup" then
-    popup = Popup(vim.tbl_deep_extend("keep", popup_opts, {
-      position = "50%",
-      size = {
-        width = "62%",
-        height = "62%",
-      },
-      padding = { 1, 1, 1, 1 },
-      enter = true,
-      focusable = true,
+    local padding = 1
+    local total_width = math.floor(vim.o.columns * 0.62)
+    local total_height = math.floor(vim.o.lines * 0.62)
+    local content_width = math.max(1, total_width - padding * 2)
+    local content_height = math.max(1, total_height - padding * 2)
+    local row = math.floor((vim.o.lines - total_height) / 2)
+    local col = math.floor((vim.o.columns - total_width) / 2)
+
+    win = vim.api.nvim_open_win(buf, true, {
+      relative = "editor",
+      row = row,
+      col = col,
+      width = content_width,
+      height = content_height,
+      style = "minimal",
+      border = "rounded",
       zindex = 50,
-      border = {
-        style = "rounded",
-      },
-    }))
-    -- Unmount component when cursor leaves buffer
-    popup:on(event.BufLeave, function()
-      popup:unmount()
-    end)
+    })
+    apply_window_options(win)
+
+    vim.api.nvim_create_autocmd("BufLeave", {
+      buffer = buf,
+      once = true,
+      callback = function()
+        if vim.api.nvim_win_is_valid(win) then
+          vim.api.nvim_win_close(win, true)
+        end
+        if vim.api.nvim_buf_is_valid(buf) then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end,
+    })
+
+    local refresh_group = vim.api.nvim_create_augroup("refresh_wtf_popup_layout", { clear = true })
+    vim.api.nvim_create_autocmd("WinResized", {
+      group = refresh_group,
+      callback = function()
+        if not vim.api.nvim_win_is_valid(win) then
+          return
+        end
+
+        local new_total_width = math.floor(vim.o.columns * 0.62)
+        local new_total_height = math.floor(vim.o.lines * 0.62)
+        local new_content_width = math.max(1, new_total_width - padding * 2)
+        local new_content_height = math.max(1, new_total_height - padding * 2)
+        local new_row = math.floor((vim.o.lines - new_total_height) / 2)
+        local new_col = math.floor((vim.o.columns - new_total_width) / 2)
+
+        vim.api.nvim_win_set_config(win, {
+          relative = "editor",
+          row = new_row,
+          col = new_col,
+          width = new_content_width,
+          height = new_content_height,
+        })
+      end,
+    })
   else
     return nil, "Invalid popup type"
   end
 
-  vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, formatted_message)
+  vim.api.nvim_buf_set_lines(buf, 0, 1, false, formatted_message)
 
-  popup:mount()
-
-  vim.api.nvim_create_autocmd("WinResized", {
-    group = vim.api.nvim_create_augroup("refresh_wtf_popup_layout", { clear = true }),
-    callback = function()
-      popup:update_layout()
-    end,
-  })
-
-  return popup
+  return { bufnr = buf, win = win }
 end
 
 return M

--- a/plugin/wtf.lua
+++ b/plugin/wtf.lua
@@ -1,8 +1,3 @@
-if vim.fn.has("nvim-0.7.0") == 0 then
-  vim.api.nvim_err_writeln("wtf requires at least nvim-0.7.0.1")
-  return
-end
-
 -- Automatically executed on startup
 if vim.g.loaded_wtf then
   return

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -5,20 +5,15 @@ local function clone_repo(repo_url, dest_dir)
 end
 
 local plenary_dir = os.getenv("PLENARY_DIR") or "/tmp/plenary.nvim"
-local nui_dir = os.getenv("NUI_DIR") or "/tmp/nui.nvim"
 
 local plenary_repo = "https://github.com/nvim-lua/plenary.nvim"
-local nui_repo = "https://github.com/MunifTanjim/nui.nvim"
 
 clone_repo(plenary_repo, plenary_dir)
-clone_repo(nui_repo, nui_dir)
 
 vim.opt.swapfile = false
 
 vim.opt.rtp:append(".")
 vim.opt.rtp:append(plenary_dir)
-vim.opt.rtp:append(nui_dir)
 
 vim.cmd.runtime({ "plugin/plenary.vim" })
-vim.cmd.runtime({ "plugin/nui.vim" })
 require("plenary.busted")

--- a/tests/wtf/wtf_spec.lua
+++ b/tests/wtf/wtf_spec.lua
@@ -9,6 +9,12 @@ describe("Setup", function()
     })
   end)
 
+  it("accepts opencode as a provider", function()
+    wtf.setup({
+      provider = "opencode",
+    })
+  end)
+
   it("rejects a broken config", function()
     assert.error_matches(function()
       wtf.setup({


### PR DESCRIPTION
# Plan: Remove nui.nvim dependency

## Decisions

- **Neovim minimum version:** 0.12+
- **Split windows:** `vim.api.nvim_open_win()` with `split = "right" | "below"`
- **Float window:** `vim.api.nvim_open_win()` with `relative = "editor"`
- **Padding:** Preserve 1-cell padding for `popup` type by shrinking the content area
- **Layout refresh:** Recalculate float geometry on `WinResized`; splits rely on the window manager

## 1. Replace `lua/wtf/ui/popup.lua`

Rewrite `M.show(message)` without any `require("nui.*")` calls.

### Helpers

```lua
local function split_string_by_line(text)
  local lines = {}
  for line in (text .. "\n"):gmatch("(.-)\n") do
    table.insert(lines, line)
  end
  return lines
end

local function create_buffer()
  local buf = vim.api.nvim_create_buf(false, true)
  vim.bo[buf].modifiable = false
  vim.bo[buf].readonly = true
  vim.bo[buf].filetype = "markdown"
  return buf
end

local function apply_window_options(win)
  vim.wo[win].wrap = true
  vim.wo[win].linebreak = true
  vim.wo[win].winhighlight = config.options.winhighlight
end
```

### `vertical` split

```lua
local win = vim.api.nvim_open_win(buf, true, {
  split = "right",
  width = math.floor(vim.o.columns * 0.5),
})
apply_window_options(win)
```

### `horizontal` split

```lua
local win = vim.api.nvim_open_win(buf, true, {
  split = "below",
  height = math.floor(vim.o.lines * 0.38),
})
apply_window_options(win)
```

### `popup` float

```lua
local padding = 1
local total_width = math.floor(vim.o.columns * 0.62)
local total_height = math.floor(vim.o.lines * 0.62)
local content_width = math.max(1, total_width - padding * 2)
local content_height = math.max(1, total_height - padding * 2)
local row = math.floor((vim.o.lines - total_height) / 2)
local col = math.floor((vim.o.columns - total_width) / 2)

local win = vim.api.nvim_open_win(buf, true, {
  relative = "editor",
  row = row,
  col = col,
  width = content_width,
  height = content_height,
  style = "minimal",
  border = "rounded",
  zindex = 50,
})
apply_window_options(win)
```

### Autocmds

- `BufLeave` for `popup` type: close the float with `vim.api.nvim_win_close(win, true)` and delete the scratch buffer.
- `WinResized`: only for `popup` type, recompute geometry and call `nvim_win_set_config(win, new_config)`.

### Return value

Keep returning an object with `bufnr` and `win` (or equivalent) so callers and tests that mock `wtf.ui.popup` continue to work.

```lua
return { bufnr = buf, win = win }
```

## 2. Update `tests/minimal_init.lua`

Remove nui cloning and runtime loading:

```diff
- local nui_dir = os.getenv("NUI_DIR") or "/tmp/nui.nvim"
- local nui_repo = "https://github.com/MunifTanjim/nui.nvim"
- clone_repo(nui_repo, nui_dir)
  vim.opt.rtp:append(".")
  vim.opt.rtp:append(plenary_dir)
- vim.opt.rtp:append(nui_dir)
  vim.cmd.runtime({ "plugin/plenary.vim" })
- vim.cmd.runtime({ "plugin/nui.vim" })
```

## 3. Update documentation

### `README.md`

Remove `"MunifTanjim/nui.nvim",` from the `dependencies` / `requires` blocks.

### `doc/wtf.nvim.txt`

Remove `"MunifTanjim/nui.nvim",` from the installation examples.

## 4. Version compatibility

- New minimum remains **Neovim 0.12**.
- `nvim_open_win` split windows require 0.10+, but this project already targets 0.12+.

## 5. Known tradeoffs

- **Manual layout math** replaces nui's `update_layout()`.
- **Padding is handled by shrinking the content area**, so the visible border sits 1 cell outside the text region. This matches the previous visual spacing.
- **No external UI framework** reduces dependencies and startup cost.

## 6. Implementation checklist

1. Rewrite `lua/wtf/ui/popup.lua` with native `nvim_open_win`.
2. Update `tests/minimal_init.lua` to remove nui.
3. Update `README.md` to remove nui.nvim dependency.
4. Update `doc/wtf.nvim.txt` to remove nui.nvim dependency.
5. Run `make lint`.
6. Run `make test`.