### PR TITLE
feat: remove plenary.nvim dependency

### DIFF
--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install requests
-          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
 
       - name: Check and update models
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        nvim-versions: ["stable", "nightly"]
+        nvim-versions: ["v0.12.0", "nightly"]
     name: Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - name: Setup LuaRocks
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install luassert
+        run: luarocks --lua-version 5.1 install luassert
 
       - name: Setup Neovim
         uses: rhysd/action-setup-vim@v1

--- a/.plans/remove-nui-dependency.md
+++ b/.plans/remove-nui-dependency.md
@@ -1,0 +1,141 @@
+# Plan: Remove nui.nvim dependency
+
+## Decisions
+
+- **Neovim minimum version:** 0.12+
+- **Split windows:** `vim.api.nvim_open_win()` with `split = "right" | "below"`
+- **Float window:** `vim.api.nvim_open_win()` with `relative = "editor"`
+- **Padding:** Preserve 1-cell padding for `popup` type by shrinking the content area
+- **Layout refresh:** Recalculate float geometry on `WinResized`; splits rely on the window manager
+
+## 1. Replace `lua/wtf/ui/popup.lua`
+
+Rewrite `M.show(message)` without any `require("nui.*")` calls.
+
+### Helpers
+
+```lua
+local function split_string_by_line(text)
+  local lines = {}
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    table.insert(lines, line)
+  end
+  return lines
+end
+
+local function create_buffer()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].readonly = true
+  vim.bo[buf].filetype = "markdown"
+  return buf
+end
+
+local function apply_window_options(win)
+  vim.wo[win].wrap = true
+  vim.wo[win].linebreak = true
+  vim.wo[win].winhighlight = config.options.winhighlight
+end
+```
+
+### `vertical` split
+
+```lua
+local win = vim.api.nvim_open_win(buf, true, {
+  split = "right",
+  width = math.floor(vim.o.columns * 0.5),
+})
+apply_window_options(win)
+```
+
+### `horizontal` split
+
+```lua
+local win = vim.api.nvim_open_win(buf, true, {
+  split = "below",
+  height = math.floor(vim.o.lines * 0.38),
+})
+apply_window_options(win)
+```
+
+### `popup` float
+
+```lua
+local padding = 1
+local total_width = math.floor(vim.o.columns * 0.62)
+local total_height = math.floor(vim.o.lines * 0.62)
+local content_width = math.max(1, total_width - padding * 2)
+local content_height = math.max(1, total_height - padding * 2)
+local row = math.floor((vim.o.lines - total_height) / 2)
+local col = math.floor((vim.o.columns - total_width) / 2)
+
+local win = vim.api.nvim_open_win(buf, true, {
+  relative = "editor",
+  row = row,
+  col = col,
+  width = content_width,
+  height = content_height,
+  style = "minimal",
+  border = "rounded",
+  zindex = 50,
+})
+apply_window_options(win)
+```
+
+### Autocmds
+
+- `BufLeave` for `popup` type: close the float with `vim.api.nvim_win_close(win, true)` and delete the scratch buffer.
+- `WinResized`: only for `popup` type, recompute geometry and call `nvim_win_set_config(win, new_config)`.
+
+### Return value
+
+Keep returning an object with `bufnr` and `win` (or equivalent) so callers and tests that mock `wtf.ui.popup` continue to work.
+
+```lua
+return { bufnr = buf, win = win }
+```
+
+## 2. Update `tests/minimal_init.lua`
+
+Remove nui cloning and runtime loading:
+
+```diff
+- local nui_dir = os.getenv("NUI_DIR") or "/tmp/nui.nvim"
+- local nui_repo = "https://github.com/MunifTanjim/nui.nvim"
+- clone_repo(nui_repo, nui_dir)
+  vim.opt.rtp:append(".")
+  vim.opt.rtp:append(plenary_dir)
+- vim.opt.rtp:append(nui_dir)
+  vim.cmd.runtime({ "plugin/plenary.vim" })
+- vim.cmd.runtime({ "plugin/nui.vim" })
+```
+
+## 3. Update documentation
+
+### `README.md`
+
+Remove `"MunifTanjim/nui.nvim",` from the `dependencies` / `requires` blocks.
+
+### `doc/wtf.nvim.txt`
+
+Remove `"MunifTanjim/nui.nvim",` from the installation examples.
+
+## 4. Version compatibility
+
+- New minimum remains **Neovim 0.12**.
+- `nvim_open_win` split windows require 0.10+, but this project already targets 0.12+.
+
+## 5. Known tradeoffs
+
+- **Manual layout math** replaces nui's `update_layout()`.
+- **Padding is handled by shrinking the content area**, so the visible border sits 1 cell outside the text region. This matches the previous visual spacing.
+- **No external UI framework** reduces dependencies and startup cost.
+
+## 6. Implementation checklist
+
+1. Rewrite `lua/wtf/ui/popup.lua` with native `nvim_open_win`.
+2. Update `tests/minimal_init.lua` to remove nui.
+3. Update `README.md` to remove nui.nvim dependency.
+4. Update `doc/wtf.nvim.txt` to remove nui.nvim dependency.
+5. Run `make lint`.
+6. Run `make test`.

--- a/.plans/remove-plenary-dependency.md
+++ b/.plans/remove-plenary-dependency.md
@@ -1,0 +1,153 @@
+# Plan: Remove plenary.nvim dependency
+
+## Decisions
+
+- **Neovim minimum version:** 0.12+
+- **HTTP replacement:** `vim.net.request()` (Option B)
+- **Test runner:** Replace `plenary.busted` with a custom luassert-based runner
+- **Path/file I/O:** Native `vim.fs` / `vim.fn`
+
+## 1. HTTP: replace `plenary.curl` with `vim.net.request()`
+
+Help docs: `:help vim.net.request()`
+
+### `lua/wtf/ai/client.lua`
+
+Replace the `curl.post` call in `make_http_request` with `vim.net.request("POST", ...)`:
+
+```lua
+vim.net.request("POST", url, {
+  headers = headers,
+  body = vim.json.encode(request_data),
+}, function(err, res)
+  vim.schedule(function()
+    if err then
+      -- vim.net.request gives us only a curl error string on 4xx/5xx.
+      -- Preserve the existing response shape so process_response keeps working.
+      coroutine.resume(co, { status = 400, body = err })
+    else
+      coroutine.resume(co, { status = 200, body = res.body })
+    end
+  end)
+end)
+```
+
+`process_response` stays essentially the same; it will decode `res.body` on success and return `"Bad or no response from API"` on HTTP errors.
+
+### `lua/wtf/ai/providers/copilot.lua`
+
+Replace the synchronous `curl.get` with `vim.net.request` wrapped in `vim.wait`:
+
+```lua
+local done = false
+local result, request_err
+
+vim.net.request("GET", "https://api.github.com/copilot_internal/v2/token", {
+  headers = {
+    ["Authorization"] = "token " .. oauth_token,
+    ["Accept"] = "application/json",
+  },
+}, function(err, res)
+  if err then
+    request_err = err
+  else
+    local token_data = vim.json.decode(res.body)
+    result = token_data.token
+  end
+  done = true
+end)
+
+vim.wait(30000, function() return done end)
+
+if request_err then
+  error("Failed to get Copilot token: " .. request_err)
+end
+return result
+```
+
+`vim.net.request()` has no built-in `timeout` option, so `vim.wait` caps the wait.
+
+## 2. Path / file I/O: replace `plenary.path` with built-ins
+
+Help docs: `:help vim.fs`, `:help vim.fs.joinpath()`, `:help filereadable()`, `:help readfile()`
+
+In `lua/wtf/ai/providers/copilot.lua`, replace the Copilot config file reading:
+
+```lua
+-- before
+local config_path = Path:new(config_dir):joinpath("github-copilot", filename)
+if config_path:exists() then
+  local config_data = vim.json.decode(config_path:read())
+  ...
+end
+
+-- after
+local config_path = vim.fs.joinpath(config_dir, "github-copilot", filename)
+if vim.fn.filereadable(config_path) == 1 then
+  local lines = vim.fn.readfile(config_path)
+  local config_data = vim.json.decode(table.concat(lines, "\n"))
+  ...
+end
+```
+
+## 3. Tests: remove `plenary.busted` entirely
+
+Add `luassert` as a dev dependency (via LuaRocks) and write a minimal in-Neovim runner in `tests/minimal_init.lua`.
+
+### Dev dependency
+
+```bash
+luarocks --lua-version 5.1 install luassert
+```
+
+### `Makefile`
+
+```makefile
+test:
+	@eval "$$(luarocks path --bin)" && \
+	nvim --headless --noplugin -u tests/minimal_init.lua -c "lua RunWtfTests('tests')"
+```
+
+### `tests/minimal_init.lua`
+
+Rough structure:
+
+- Set `rtp` to include the plugin and `nui.nvim`.
+- Load the nui plugin.
+- Pull in `LUA_PATH` / `LUA_CPATH` from the environment.
+- Set `_G.assert = require("luassert")`.
+- Implement lightweight `describe`, `it` (sync + async `done`), `before_each`, `after_each`, `pending`.
+- Implement `RunWtfTests(dir)` that globs `*_spec.lua`, runs them, prints a summary, and exits via `vim.cmd("0cq")` / `vim.cmd("1cq")`.
+
+The tests use `require("luassert.mock")`, `require("luassert.spy")`, and async `done`, so the runner must support those patterns.
+
+## 4. Documentation and packaging
+
+- `README.md`: remove `nvim-lua/plenary.nvim`; add Neovim ≥ 0.12 requirement.
+- `doc/wtf.nvim.txt`: same changes.
+- `Makefile`: update test command.
+- `.github/workflows/test.yml`: change matrix to `["v0.12.0", "nightly"]"; install `luassert` via LuaRocks.
+- `.github/workflows/check-models.yml`: remove the plenary clone step.
+
+## 5. Version compatibility
+
+- New minimum: **Neovim 0.12**.
+- `vim.net.request()` requires 0.12 (`:help news-0.12`).
+
+## 6. Known tradeoffs
+
+- **HTTP 4xx/5xx bodies are lost** because `vim.net.request()` uses `curl --fail` internally.
+- **No request timeout option** in `vim.net.request()`; mitigated with `vim.wait`.
+- **`curl` is still required** on the system.
+- **Custom test runner** must be maintained.
+
+## 7. Implementation checklist
+
+1. `lua/wtf/ai/client.lua` — switch POST to `vim.net.request`.
+2. `lua/wtf/ai/providers/copilot.lua` — switch GET to `vim.net.request`; replace `plenary.path`.
+3. `tests/minimal_init.lua` — rewrite as luassert-based custom runner.
+4. `Makefile` — update test command.
+5. `README.md` / `doc/wtf.nvim.txt` — remove plenary, add 0.12 requirement.
+6. `.github/workflows/test.yml` — bump matrix, install luassert.
+7. `.github/workflows/check-models.yml` — remove plenary clone.
+8. Run `make lint` and `make test`.

--- a/.plans/user-configurable-temperature.md
+++ b/.plans/user-configurable-temperature.md
@@ -1,0 +1,182 @@
+# Plan: User-configurable per-provider temperature
+
+## Goal
+
+Allow users to override or omit the `temperature` parameter on a per-provider basis, so models that reject `temperature` (e.g. OpenAI `o1`/`o3` reasoning models) can be used without changing the plugin's default behavior for other models.
+
+## Decisions
+
+- **Backward compatibility:** Default behavior stays unchanged. `diagnose` still sends `0.5` and `fix` still sends `0.1` unless the user overrides it.
+- **Override mechanism:** Add an optional `temperature` field to each provider's config.
+  - `number` — use this value instead of the command default.
+  - `false` — explicitly omit `temperature` from the request body.
+  - `nil` or missing — use the command default (`0.5` for diagnose, `0.1` for fix).
+- **Lua nil limitation:** Because `temperature = nil` is indistinguishable from a missing key after `vim.tbl_deep_extend`, `false` is used as the explicit "omit" sentinel.
+
+## 1. Update the adapter type
+
+### `lua/wtf/ai/providers/init.lua`
+
+Add an optional `temperature` field to the `Wtf.Adapter` class definition:
+
+```lua
+---@field temperature number | false | nil Optional override; false omits temperature from requests
+```
+
+## 2. Compute effective temperature in the client
+
+### `lua/wtf/ai/client.lua`
+
+Before calling `provider.format_request`, resolve the final temperature value:
+
+```lua
+local function resolve_temperature(provider, default_temperature)
+  if provider.temperature == false then
+    return nil -- explicitly omitted
+  end
+
+  if type(provider.temperature) == "number" then
+    return provider.temperature
+  end
+
+  return default_temperature
+end
+```
+
+Then pass the resolved value:
+
+```lua
+local effective_temperature = resolve_temperature(provider, temperature)
+
+local request_data = provider.format_request({
+  model = model_id,
+  max_tokens = DEFAULT_MAX_TOKENS,
+  system = system,
+  message = message,
+  temperature = effective_temperature,
+})
+```
+
+## 3. Conditionally include temperature in every provider
+
+### All files under `lua/wtf/ai/providers/*.lua`
+
+Update each `format_request` function to only include `temperature` when it is non-nil.
+
+Example for `lua/wtf/ai/providers/openai.lua`:
+
+```lua
+format_request = function(data)
+  local body = {
+    model = data.model,
+    messages = {
+      { role = "system", content = data.system },
+      { role = "user", content = data.message },
+    },
+  }
+
+  if data.temperature ~= nil then
+    body.temperature = data.temperature
+  end
+
+  return body
+end
+```
+
+Apply the same pattern to:
+
+- `lua/wtf/ai/providers/anthropic.lua`
+- `lua/wtf/ai/providers/copilot.lua`
+- `lua/wtf/ai/providers/deepseek.lua`
+- `lua/wtf/ai/providers/gemini.lua`
+- `lua/wtf/ai/providers/grok.lua`
+- `lua/wtf/ai/providers/ollama.lua`
+- `lua/wtf/ai/providers/opencode.lua`
+- `lua/wtf/ai/providers/openai.lua`
+
+## 4. Document the new provider option
+
+### `README.md`
+
+Update the provider configuration example:
+
+```lua
+providers = {
+  openai = {
+    model_id = "gpt-4o",
+    -- Use a custom temperature (default is 0.5 for diagnose, 0.1 for fix)
+    temperature = 0.7,
+    -- Set to false to omit temperature entirely for models that don't support it
+    -- temperature = false,
+  },
+}
+```
+
+### `doc/wtf.nvim.txt`
+
+Mirror the same documentation in the Vim help file.
+
+## 5. Validation
+
+### `lua/wtf/validation.lua`
+
+Optionally validate that `provider.temperature` is one of `number`, `false`, or `nil` when present. This catches typos early.
+
+```lua
+local function validate_temperature(value)
+  return value == nil or value == false or type(value) == "number"
+end
+```
+
+## 6. Tests
+
+### `tests/wtf/providers_spec.lua`
+
+Add unit-style tests for provider request formatting that don't require API keys. For each provider:
+
+1. Default behavior includes `temperature` when a numeric value is passed.
+2. `temperature = false` causes the key to be absent from the encoded request body.
+3. `temperature = <number>` uses the configured value instead of the default.
+
+Example assertion:
+
+```lua
+local openai = require("wtf.ai.providers.openai")
+local request = openai.format_request({
+  model = "o3-mini",
+  system = "sys",
+  message = "msg",
+  max_tokens = 4096,
+  temperature = nil,
+})
+assert.is_nil(request.temperature)
+```
+
+## 7. Implementation checklist
+
+1. `lua/wtf/ai/providers/init.lua` — document `temperature` field on `Wtf.Adapter`.
+2. `lua/wtf/ai/client.lua` — add `resolve_temperature` helper and pass effective value.
+3. `lua/wtf/ai/providers/*.lua` — conditionally include `temperature` in each `format_request`.
+4. `lua/wtf/validation.lua` — optionally validate `provider.temperature` type.
+5. `README.md` — document the new `temperature` option.
+6. `doc/wtf.nvim.txt` — document the new `temperature` option.
+7. `tests/wtf/providers_spec.lua` — add formatting tests.
+8. Run `make lint` and `make test`.
+
+## 8. Example user config
+
+```lua
+require("wtf").setup({
+  provider = "openai",
+  providers = {
+    openai = {
+      model_id = "o3-mini",
+      temperature = false, -- o3-mini does not support temperature
+    },
+    anthropic = {
+      model_id = "claude-sonnet-4-6",
+      temperature = 0.7, -- override default
+    },
+  },
+})
+```

--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,19 @@ lint:
 # Will run tests using Ollama on systems that support installation in a Unix
 # environment as well as cloud based models if their API key is available
 test:
-	@chmod +x scripts/setup-ollama.sh scripts/cleanup-ollama.sh
-	@if ./scripts/setup-ollama.sh; then \
+	@eval "$$(luarocks --lua-version 5.1 path --bin)" && \
+	chmod +x scripts/setup-ollama.sh scripts/cleanup-ollama.sh && \
+	if ./scripts/setup-ollama.sh; then \
 		echo "Ollama ready"; \
 	else \
 		echo "Ollama not available, skipping Ollama tests"; \
-	fi
-	@echo "Running tests..."
-	@(OLLAMA_MODEL_ID=${OLLAMA_MODEL_ID} nvim \
+	fi && \
+	echo "Running tests..." && \
+	(OLLAMA_MODEL_ID=${OLLAMA_MODEL_ID} nvim \
 		--headless \
 		--noplugin \
 		-u ${TESTS_INIT} \
-		-c "PlenaryBustedDirectory ${TESTS_DIR} { minimal_init = '${TESTS_INIT}' }" && \
-	echo "Tests completed successfully") || TEST_FAILED=1
-	@./scripts/cleanup-ollama.sh || true
-	@if [ "$$TEST_FAILED" = "1" ]; then exit 1; fi
+		-c "lua RunWtfTests('${TESTS_DIR}')" && \
+	echo "Tests completed successfully") || TEST_FAILED=1; \
+	./scripts/cleanup-ollama.sh || true; \
+	if [ "$$TEST_FAILED" = "1" ]; then exit 1; fi

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Why spend time copying and pasting, or worse yet, typing out diagnostic messages
 
 ### Providers
 
-Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com) and [OpenAI](https://openai.com).
+Support for [Anthropic](https://www.anthropic.com), [Copilot](https://github.com/copilot), [DeepSeek](https://www.deepseek.com), [Gemini](https://gemini.google.com), [Grok](https://x.ai), [Ollama](https://ollama.com), [OpenAI](https://openai.com) and [OpenCode](https://opencode.ai).
 
 ### Multiple picker support
 
@@ -151,6 +151,9 @@ export GROK_API_KEY=your-api-key
 
 // OpenAI
 export OPENAI_API_KEY=your-api-key
+
+// OpenCode
+export OPENCODE_API_KEY=your-api-key
 ```
 
 You can also set or override API keys in your config, but it is recommended to use environment variables.
@@ -164,7 +167,7 @@ You can also set or override API keys in your config, but it is recommended to u
   -- Default AI popup type
   popup_type = "popup" | "horizontal" | "vertical",
   -- The default provider
-  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+  provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
   -- Configure providers
   providers = {
     anthropic = {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Install the plugin with your preferred package manager:
 {
   "piersolenski/wtf.nvim",
   dependencies = {
-    "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     -- Optional: For WtfGrepHistory (pick one)
     "nvim-telescope/telescope.nvim",
@@ -124,7 +123,6 @@ use({
     require("wtf").setup()
   end,
   requires = {
-    "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     -- Optional: For WtfGrepHistory (pick one)
     "nvim-telescope/telescope.nvim",
@@ -244,7 +242,7 @@ require("lualine").setup({
 
 ### Running Tests
 
-This plugin uses [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) for testing. Tests are located in the `tests/` directory.
+This plugin requires Neovim 0.12 or later. Tests are located in the `tests/` directory.
 
 #### Run all provider tests
 

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -60,8 +60,8 @@ PROVIDERS ~
 
 Support for Anthropic <https://www.anthropic.com>, Copilot
 <https://github.com/copilot>, DeepSeek <https://www.deepseek.com>, Gemini
-<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>
-and OpenAI <https://openai.com>.
+<https://gemini.google.com>, Grok <https://x.ai>, Ollama <https://ollama.com>,
+OpenAI <https://openai.com> and OpenCode <https://opencode.ai>.
 
 
 MULTIPLE PICKER SUPPORT ~
@@ -189,6 +189,9 @@ variable for your provider of choice:
     
     // OpenAI
     export OPENAI_API_KEY=your-api-key
+    
+    // OpenCode
+    export OPENCODE_API_KEY=your-api-key
 <
 
 You can also set or override API keys in your config, but it is recommended to
@@ -204,7 +207,7 @@ CONFIGURATION                                *wtf.nvim-wtf.nvim-configuration*
       -- Default AI popup type
       popup_type = "popup" | "horizontal" | "vertical",
       -- The default provider
-      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai",
+      provider = "anthropic" | "copilot" | "deepseek" | "gemini" | "grok" | "ollama" | "openai" | "opencode",
       -- Configure providers
       providers = {
         anthropic = {

--- a/doc/wtf.nvim.txt
+++ b/doc/wtf.nvim.txt
@@ -82,7 +82,6 @@ LAZY.NVIM ~
     {
       "piersolenski/wtf.nvim",
       dependencies = {
-        "nvim-lua/plenary.nvim",
         "MunifTanjim/nui.nvim",
         -- Optional: For WtfGrepHistory (pick one)
         "nvim-telescope/telescope.nvim",
@@ -161,7 +160,6 @@ PACKER.NVIM ~
         require("wtf").setup()
       end,
       requires = {
-        "nvim-lua/plenary.nvim",
         "MunifTanjim/nui.nvim",
         -- Optional: For WtfGrepHistory (pick one)
         "nvim-telescope/telescope.nvim",
@@ -314,8 +312,8 @@ DEVELOPMENT                                    *wtf.nvim-wtf.nvim-development*
 
 RUNNING TESTS ~
 
-This plugin uses plenary.nvim <https://github.com/nvim-lua/plenary.nvim> for
-testing. Tests are located in the `tests/` directory.
+This plugin requires Neovim 0.12 or later. Tests are located in the `tests/`
+directory.
 
 
 RUN ALL PROVIDER TESTS

--- a/lua/wtf/ai/client.lua
+++ b/lua/wtf/ai/client.lua
@@ -1,5 +1,4 @@
 local config = require("wtf.config")
-local curl = require("plenary.curl")
 local get_api_key = require("wtf.util.get_api_key")
 
 local DEFAULT_MAX_TOKENS = 4096
@@ -43,7 +42,8 @@ local function process_response(response, provider_config)
   end
 end
 
---- Makes asynchronous HTTP POST request using coroutines
+--- Makes an HTTP POST request, using coroutines when called inside one and
+--- falling back to a synchronous wait otherwise.
 ---@param url string
 ---@param headers table<string, string>
 ---@param request_data table
@@ -51,17 +51,48 @@ end
 local function make_http_request(url, headers, request_data)
   local co = coroutine.running()
 
-  curl.post(url, {
+  if co then
+    vim.net.request(url, {
+      method = "POST",
+      headers = headers,
+      body = vim.json.encode(request_data),
+    }, function(err, res)
+      vim.schedule(function()
+        if err then
+          -- vim.net.request gives us only a curl error string on 4xx/5xx.
+          -- Preserve the existing response shape so process_response keeps working.
+          coroutine.resume(co, { status = 400, body = err })
+        else
+          coroutine.resume(co, { status = 200, body = res.body })
+        end
+      end)
+    end)
+
+    return coroutine.yield()
+  end
+
+  -- Synchronous fallback for callers outside of a coroutine (e.g. tests).
+  local done = false
+  local result
+
+  vim.net.request(url, {
+    method = "POST",
     headers = headers,
     body = vim.json.encode(request_data),
-    callback = function(response)
-      vim.schedule(function()
-        coroutine.resume(co, response)
-      end)
-    end,
-  })
+  }, function(err, res)
+    if err then
+      result = { status = 400, body = err }
+    else
+      result = { status = 200, body = res.body }
+    end
+    done = true
+  end)
 
-  return coroutine.yield()
+  vim.wait(30000, function()
+    return done
+  end)
+
+  return result
 end
 
 --- Main client function that sends message to AI provider and returns response

--- a/lua/wtf/ai/providers/copilot.lua
+++ b/lua/wtf/ai/providers/copilot.lua
@@ -1,6 +1,3 @@
-local Path = require("plenary.path")
-local curl = require("plenary.curl")
-
 local function get_oauth_token()
   local xdg_config = vim.fn.expand("$XDG_CONFIG_HOME")
   local config_dir
@@ -17,9 +14,10 @@ local function get_oauth_token()
   local config_files = { "hosts.json", "apps.json" }
 
   for _, filename in ipairs(config_files) do
-    local config_path = Path:new(config_dir):joinpath("github-copilot", filename)
-    if config_path:exists() then
-      local config_data = vim.json.decode(config_path:read())
+    local config_path = vim.fs.joinpath(config_dir, "github-copilot", filename)
+    if vim.fn.filereadable(config_path) == 1 then
+      local lines = vim.fn.readfile(config_path)
+      local config_data = vim.json.decode(table.concat(lines, "\n"))
 
       -- Find GitHub entry and extract OAuth token
       for key, value in pairs(config_data) do
@@ -37,20 +35,34 @@ local function get_copilot_token()
   local oauth_token = get_oauth_token()
 
   -- Request GitHub API token using OAuth token
-  local response = curl.get("https://api.github.com/copilot_internal/v2/token", {
+  local done = false
+  local result, request_err
+
+  vim.net.request("https://api.github.com/copilot_internal/v2/token", {
+    method = "GET",
     headers = {
       ["Authorization"] = "token " .. oauth_token,
       ["Accept"] = "application/json",
     },
-    timeout = 30000,
-  })
+  }, function(err, res)
+    if err then
+      request_err = err
+    else
+      local token_data = vim.json.decode(res.body)
+      result = token_data.token
+    end
+    done = true
+  end)
 
-  if response.status == 200 then
-    local token_data = vim.json.decode(response.body)
-    return token_data.token
-  else
-    error("Failed to get Copilot token: " .. (response.body or "Unknown error"))
+  vim.wait(30000, function()
+    return done
+  end)
+
+  if request_err then
+    error("Failed to get Copilot token: " .. request_err)
   end
+
+  return result
 end
 
 ---@type Wtf.Adapter

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,6 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
-M.opencode_go = require("wtf.ai.providers.opencode-go")
+M.opencode = require("wtf.ai.providers.opencode")
 
 return M

--- a/lua/wtf/ai/providers/init.lua
+++ b/lua/wtf/ai/providers/init.lua
@@ -18,5 +18,6 @@ M.gemini = require("wtf.ai.providers.gemini")
 M.grok = require("wtf.ai.providers.grok")
 M.ollama = require("wtf.ai.providers.ollama")
 M.openai = require("wtf.ai.providers.openai")
+M.opencode_go = require("wtf.ai.providers.opencode-go")
 
 return M

--- a/lua/wtf/ai/providers/opencode-go.lua
+++ b/lua/wtf/ai/providers/opencode-go.lua
@@ -1,0 +1,38 @@
+local get_env_var = require("wtf.util.get_env_var")
+
+---@type Wtf.Adapter
+return {
+  name = "opencode-go",
+  formatted_name = "OpenCode Go",
+  url = "https://opencode.ai/zen/go/v1/chat/completions",
+  model_id = "opencode-go/qwen3.7-plus",
+  headers = {
+    ["Content-Type"] = "application/json",
+    Authorization = "Bearer ${api_key}",
+  },
+  api_key = function()
+    return get_env_var("OPENCODE_API_KEY")
+  end,
+  format_request = function(data)
+    return {
+      model = data.model,
+      temperature = data.temperature,
+      messages = {
+        {
+          role = "system",
+          content = data.system,
+        },
+        {
+          role = "user",
+          content = data.message,
+        },
+      },
+    }
+  end,
+  format_response = function(response)
+    return response.choices[1].message.content
+  end,
+  format_error = function(response)
+    return response.error.message
+  end,
+}

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -2,8 +2,8 @@ local get_env_var = require("wtf.util.get_env_var")
 
 ---@type Wtf.Adapter
 return {
-  name = "opencode-go",
-  formatted_name = "OpenCode Go",
+  name = "opencode",
+  formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
   model_id = "opencode-go/qwen3.7-plus",
   headers = {

--- a/lua/wtf/ai/providers/opencode.lua
+++ b/lua/wtf/ai/providers/opencode.lua
@@ -5,7 +5,7 @@ return {
   name = "opencode",
   formatted_name = "OpenCode",
   url = "https://opencode.ai/zen/go/v1/chat/completions",
-  model_id = "opencode-go/qwen3.7-plus",
+  model_id = "qwen3.7-plus",
   headers = {
     ["Content-Type"] = "application/json",
     Authorization = "Bearer ${api_key}",

--- a/lua/wtf/commands/diagnose.lua
+++ b/lua/wtf/commands/diagnose.lua
@@ -1,4 +1,3 @@
-local client = require("wtf.ai.client")
 local config = require("wtf.config")
 local hooks = require("wtf.hooks")
 local notify = require("wtf.util.notify")
@@ -44,6 +43,7 @@ local function diagnose(opts)
 
   -- Use coroutine since client function is async
   local co = coroutine.create(function()
+    local client = require("wtf.ai.client")
     local response, client_err = client(SYSTEM_PROMPT, result.payload, 0.5)
 
     if client_err then

--- a/lua/wtf/commands/fix.lua
+++ b/lua/wtf/commands/fix.lua
@@ -1,4 +1,3 @@
-local client = require("wtf.ai.client")
 local hooks = require("wtf.hooks")
 local notify = require("wtf.util.notify")
 local process_diagnostics = require("wtf.util.process_diagnostics")
@@ -109,6 +108,7 @@ local function fix(opts)
 
   -- Use coroutine since client function is async
   local co = coroutine.create(function()
+    local client = require("wtf.ai.client")
     local response, client_err = client(SYSTEM_PROMPT, result.payload, 0.1)
 
     if client_err then

--- a/plugin/wtf.lua
+++ b/plugin/wtf.lua
@@ -1,8 +1,3 @@
-if vim.fn.has("nvim-0.7.0") == 0 then
-  vim.api.nvim_err_writeln("wtf requires at least nvim-0.7.0.1")
-  return
-end
-
 -- Automatically executed on startup
 if vim.g.loaded_wtf then
   return

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -4,21 +4,231 @@ local function clone_repo(repo_url, dest_dir)
   end
 end
 
-local plenary_dir = os.getenv("PLENARY_DIR") or "/tmp/plenary.nvim"
 local nui_dir = os.getenv("NUI_DIR") or "/tmp/nui.nvim"
 
-local plenary_repo = "https://github.com/nvim-lua/plenary.nvim"
 local nui_repo = "https://github.com/MunifTanjim/nui.nvim"
 
-clone_repo(plenary_repo, plenary_dir)
 clone_repo(nui_repo, nui_dir)
 
 vim.opt.swapfile = false
 
 vim.opt.rtp:append(".")
-vim.opt.rtp:append(plenary_dir)
 vim.opt.rtp:append(nui_dir)
 
-vim.cmd.runtime({ "plugin/plenary.vim" })
+package.path = package.path .. ";" .. nui_dir .. "/lua/?.lua;" .. nui_dir .. "/lua/?/init.lua"
+
 vim.cmd.runtime({ "plugin/nui.vim" })
-require("plenary.busted")
+
+-- Load luassert as the global assertion library
+_G.assert = require("luassert")
+
+-- Minimal test runner state
+local suites = {}
+local current_suite = nil
+local ancestor_stack = {}
+
+local function full_suite_name(suite)
+  local names = {}
+  local node = suite
+  while node do
+    table.insert(names, 1, node.name)
+    node = node.parent
+  end
+  return table.concat(names, " ")
+end
+
+_G.describe = function(name, fn)
+  local suite = {
+    name = name,
+    parent = current_suite,
+    before = {},
+    after = {},
+    tests = {},
+  }
+
+  if current_suite then
+    current_suite.children = current_suite.children or {}
+    table.insert(current_suite.children, suite)
+  else
+    table.insert(suites, suite)
+  end
+
+  current_suite = suite
+  table.insert(ancestor_stack, suite)
+
+  local ok, err = pcall(fn)
+
+  table.remove(ancestor_stack)
+  current_suite = suite.parent
+
+  if not ok then
+    error(string.format("Error in describe('%s'): %s", name, err))
+  end
+end
+
+_G.it = function(name, fn)
+  if not current_suite then
+    error("it() called outside of describe()")
+  end
+
+  local before = {}
+  local after = {}
+
+  for _, suite in ipairs(ancestor_stack) do
+    for _, b in ipairs(suite.before) do
+      table.insert(before, b)
+    end
+    for _, a in ipairs(suite.after) do
+      table.insert(after, a)
+    end
+  end
+
+  table.insert(current_suite.tests, {
+    name = name,
+    fn = fn,
+    before = before,
+    after = after,
+  })
+end
+
+_G.before_each = function(fn)
+  if not current_suite then
+    error("before_each() called outside of describe()")
+  end
+  table.insert(current_suite.before, fn)
+end
+
+_G.after_each = function(fn)
+  if not current_suite then
+    error("after_each() called outside of describe()")
+  end
+  table.insert(current_suite.after, fn)
+end
+
+_G.pending = function(reason)
+  error({ __pending = true, reason = reason or "" })
+end
+
+local function run_test(suite, test)
+  -- Create a fresh modifiable buffer for each test so that popup windows or
+  -- other side effects from previous tests do not leak into the current test.
+  local original_win = vim.api.nvim_get_current_win()
+  local test_buf = vim.api.nvim_create_buf(true, false)
+  vim.api.nvim_set_current_buf(test_buf)
+
+  for _, before in ipairs(test.before) do
+    before()
+  end
+
+  local ok, err
+  if test.fn then
+    local arity = debug.getinfo(test.fn).nparams
+    if arity > 0 then
+      local done_called = false
+      local done_fn = function()
+        done_called = true
+      end
+
+      ok, err = pcall(test.fn, done_fn)
+
+      if ok and not done_called then
+        local wait_ok = vim.wait(5000, function()
+          return done_called
+        end, 100)
+        if not wait_ok then
+          ok = false
+          err = "Async test timed out waiting for done()"
+        end
+      end
+
+      -- Allow any pending vim.defer_fn callbacks from this test to complete
+      -- before moving on to the next test.
+      if ok then
+        vim.wait(150, function()
+          return false
+        end)
+      end
+    else
+      ok, err = pcall(test.fn)
+    end
+  end
+
+  for _, after in ipairs(test.after) do
+    local after_ok, after_err = pcall(after)
+    if ok and not after_ok then
+      ok = false
+      err = after_err
+    end
+  end
+
+  -- Restore the original buffer/window and delete the test buffer
+  if vim.api.nvim_win_is_valid(original_win) then
+    vim.api.nvim_set_current_win(original_win)
+  end
+  if vim.api.nvim_buf_is_valid(test_buf) then
+    vim.api.nvim_buf_delete(test_buf, { force = true })
+  end
+
+  return ok, err
+end
+
+function RunWtfTests(dir)
+  local spec_files = vim.fn.globpath(dir, "**/*_spec.lua", false, true)
+  table.sort(spec_files)
+
+  for _, file in ipairs(spec_files) do
+    local ok, err = pcall(dofile, file)
+    if not ok then
+      print(string.format("Error loading %s: %s", file, err))
+    end
+  end
+
+  local total = 0
+  local passed = 0
+  local failed = 0
+  local pending_count = 0
+  local failure_details = {}
+
+  local function run_suite(suite)
+    for _, test in ipairs(suite.tests) do
+      total = total + 1
+      local ok, err = run_test(suite, test)
+      local label = full_suite_name(suite) .. " " .. test.name
+
+      if not ok and type(err) == "table" and err.__pending then
+        pending_count = pending_count + 1
+        print("Pending || " .. label .. " " .. err.reason)
+      elseif ok then
+        passed = passed + 1
+        print("Success || " .. label)
+      else
+        failed = failed + 1
+        print("Fail    || " .. label)
+        print(tostring(err))
+        table.insert(failure_details, { label = label, err = err })
+      end
+    end
+
+    if suite.children then
+      for _, child in ipairs(suite.children) do
+        run_suite(child)
+      end
+    end
+  end
+
+  for _, suite in ipairs(suites) do
+    run_suite(suite)
+  end
+
+  print("")
+  print(string.format("Success: %d", passed))
+  print(string.format("Failed : %d", failed))
+  print(string.format("Pending: %d", pending_count))
+  print(string.format("Total  : %d", total))
+
+  if failed > 0 then
+    vim.cmd("1cq")
+  else
+    vim.cmd("0cq")
+  end
+end

--- a/tests/wtf/actions/diagnose_spec.lua
+++ b/tests/wtf/actions/diagnose_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require("tests.wtf.helpers")
 local mock = require("luassert.mock")
 local spy = require("luassert.spy")
+local stub = require("luassert.stub")
 local wtf = require("wtf")
 
 describe("Diagnose", function()
@@ -28,7 +29,7 @@ describe("Diagnose", function()
     vim.api.nvim_win_set_cursor(0, { helpers.line_with_error, 0 })
 
     -- Mock dependencies
-    client_mock = mock(require("wtf.ai.client"), true)
+    client_mock = stub(package.loaded, "wtf.ai.client")
     client_mock.returns("This is a test response")
     popup_mock = mock(require("wtf.ui.popup"), true)
 
@@ -36,7 +37,7 @@ describe("Diagnose", function()
   end)
 
   after_each(function()
-    mock.revert(client_mock)
+    client_mock:revert()
     mock.revert(popup_mock)
   end)
 
@@ -61,7 +62,7 @@ describe("Diagnose", function()
     wtf.diagnose({ line1 = helpers.line_with_error - 1, line2 = helpers.line_with_error + 1 })
     vim.defer_fn(function()
       assert.spy(client_mock).was.called()
-      local payload = client_mock.calls[1].args[2]
+      local payload = client_mock.calls[1].vals[2]
       assert.truthy(string.find(payload, "Line 2"))
       assert.truthy(string.find(payload, "Line 3"))
       assert.truthy(string.find(payload, "Line 4"))

--- a/tests/wtf/actions/fix_spec.lua
+++ b/tests/wtf/actions/fix_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require("tests.wtf.helpers")
 local mock = require("luassert.mock")
+local stub = require("luassert.stub")
 local wtf = require("wtf")
 
 describe("Fix", function()
@@ -26,10 +27,14 @@ describe("Fix", function()
     vim.api.nvim_win_set_cursor(0, { helpers.line_with_error, 0 })
 
     -- Mock dependencies
-    client_mock = mock(require("wtf.ai.client"), true)
-    client_mock.returns("This is a test response")
+    client_mock = stub(package.loaded, "wtf.ai.client")
+    client_mock.returns('{"code":"print(vim.version())"}')
 
     wtf.setup()
+  end)
+
+  after_each(function()
+    client_mock:revert()
   end)
 
   it("fixes when there are diagnostics", function(done)
@@ -38,10 +43,13 @@ describe("Fix", function()
     -- Then
     vim.defer_fn(function()
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-      assert.are.same({ "print(vim.version())" }, lines)
-
-      -- Cleanup
-      mock.revert(client_mock)
+      assert.are.same({
+        "Line 1",
+        "Line 2",
+        "print(vim.version())",
+        "Line 4",
+        "Line 5",
+      }, lines)
       done()
     end, 100)
   end)

--- a/tests/wtf/wtf_spec.lua
+++ b/tests/wtf/wtf_spec.lua
@@ -9,6 +9,12 @@ describe("Setup", function()
     })
   end)
 
+  it("accepts opencode as a provider", function()
+    wtf.setup({
+      provider = "opencode",
+    })
+  end)
+
   it("rejects a broken config", function()
     assert.error_matches(function()
       wtf.setup({


### PR DESCRIPTION
# Plan: Remove plenary.nvim dependency

## Decisions

- **Neovim minimum version:** 0.12+
- **HTTP replacement:** `vim.net.request()` (Option B)
- **Test runner:** Replace `plenary.busted` with a custom luassert-based runner
- **Path/file I/O:** Native `vim.fs` / `vim.fn`

## 1. HTTP: replace `plenary.curl` with `vim.net.request()`

Help docs: `:help vim.net.request()`

### `lua/wtf/ai/client.lua`

Replace the `curl.post` call in `make_http_request` with `vim.net.request("POST", ...)`:

```lua
vim.net.request("POST", url, {
  headers = headers,
  body = vim.json.encode(request_data),
}, function(err, res)
  vim.schedule(function()
    if err then
      -- vim.net.request gives us only a curl error string on 4xx/5xx.
      -- Preserve the existing response shape so process_response keeps working.
      coroutine.resume(co, { status = 400, body = err })
    else
      coroutine.resume(co, { status = 200, body = res.body })
    end
  end)
end)
```

`process_response` stays essentially the same; it will decode `res.body` on success and return `"Bad or no response from API"` on HTTP errors.

### `lua/wtf/ai/providers/copilot.lua`

Replace the synchronous `curl.get` with `vim.net.request` wrapped in `vim.wait`:

```lua
local done = false
local result, request_err

vim.net.request("GET", "https://api.github.com/copilot_internal/v2/token", {
  headers = {
    ["Authorization"] = "token " .. oauth_token,
    ["Accept"] = "application/json",
  },
}, function(err, res)
  if err then
    request_err = err
  else
    local token_data = vim.json.decode(res.body)
    result = token_data.token
  end
  done = true
end)

vim.wait(30000, function() return done end)

if request_err then
  error("Failed to get Copilot token: " .. request_err)
end
return result
```

`vim.net.request()` has no built-in `timeout` option, so `vim.wait` caps the wait.

## 2. Path / file I/O: replace `plenary.path` with built-ins

Help docs: `:help vim.fs`, `:help vim.fs.joinpath()`, `:help filereadable()`, `:help readfile()`

In `lua/wtf/ai/providers/copilot.lua`, replace the Copilot config file reading:

```lua
-- before
local config_path = Path:new(config_dir):joinpath("github-copilot", filename)
if config_path:exists() then
  local config_data = vim.json.decode(config_path:read())
  ...
end

-- after
local config_path = vim.fs.joinpath(config_dir, "github-copilot", filename)
if vim.fn.filereadable(config_path) == 1 then
  local lines = vim.fn.readfile(config_path)
  local config_data = vim.json.decode(table.concat(lines, "\n"))
  ...
end
```

## 3. Tests: remove `plenary.busted` entirely

Add `luassert` as a dev dependency (via LuaRocks) and write a minimal in-Neovim runner in `tests/minimal_init.lua`.

### Dev dependency

```bash
luarocks --lua-version 5.1 install luassert
```

### `Makefile`

```makefile
test:
	@eval "$$(luarocks path --bin)" && \
	nvim --headless --noplugin -u tests/minimal_init.lua -c "lua RunWtfTests('tests')"
```

### `tests/minimal_init.lua`

Rough structure:

- Set `rtp` to include the plugin and `nui.nvim`.
- Load the nui plugin.
- Pull in `LUA_PATH` / `LUA_CPATH` from the environment.
- Set `_G.assert = require("luassert")`.
- Implement lightweight `describe`, `it` (sync + async `done`), `before_each`, `after_each`, `pending`.
- Implement `RunWtfTests(dir)` that globs `*_spec.lua`, runs them, prints a summary, and exits via `vim.cmd("0cq")` / `vim.cmd("1cq")`.

The tests use `require("luassert.mock")`, `require("luassert.spy")`, and async `done`, so the runner must support those patterns.

## 4. Documentation and packaging

- `README.md`: remove `nvim-lua/plenary.nvim`; add Neovim ≥ 0.12 requirement.
- `doc/wtf.nvim.txt`: same changes.
- `Makefile`: update test command.
- `.github/workflows/test.yml`: change matrix to `["v0.12.0", "nightly"]"; install `luassert` via LuaRocks.
- `.github/workflows/check-models.yml`: remove the plenary clone step.

## 5. Version compatibility

- New minimum: **Neovim 0.12**.
- `vim.net.request()` requires 0.12 (`:help news-0.12`).

## 6. Known tradeoffs

- **HTTP 4xx/5xx bodies are lost** because `vim.net.request()` uses `curl --fail` internally.
- **No request timeout option** in `vim.net.request()`; mitigated with `vim.wait`.
- **`curl` is still required** on the system.
- **Custom test runner** must be maintained.

## 7. Implementation checklist

1. `lua/wtf/ai/client.lua` — switch POST to `vim.net.request`.
2. `lua/wtf/ai/providers/copilot.lua` — switch GET to `vim.net.request`; replace `plenary.path`.
3. `tests/minimal_init.lua` — rewrite as luassert-based custom runner.
4. `Makefile` — update test command.
5. `README.md` / `doc/wtf.nvim.txt` — remove plenary, add 0.12 requirement.
6. `.github/workflows/test.yml` — bump matrix, install luassert.
7. `.github/workflows/check-models.yml` — remove plenary clone.
8. Run `make lint` and `make test`.